### PR TITLE
Remove DocumentRangeFormattingEditProvider

### DIFF
--- a/src/languageFeatures.ts
+++ b/src/languageFeatures.ts
@@ -2,7 +2,6 @@ import {
   editor,
   IDisposable,
   IMarkdownString,
-  IRange,
   languages,
   MarkerSeverity,
   Position,
@@ -152,18 +151,6 @@ function fromPosition(position: Position): ls.Position {
   return { character: position.column - 1, line: position.lineNumber - 1 };
 }
 
-function fromRange(range: IRange): ls.Range {
-  if (!range) {
-    return;
-  }
-  return {
-    start: {
-      line: range.startLineNumber - 1,
-      character: range.startColumn - 1,
-    },
-    end: { line: range.endLineNumber - 1, character: range.endColumn - 1 },
-  };
-}
 function toRange(range: ls.Range): Range {
   if (!range) {
     return;
@@ -451,30 +438,6 @@ export class DocumentFormattingEditProvider implements languages.DocumentFormatt
         }
         return edits.map(toTextEdit);
       }),
-    );
-  }
-}
-
-export class DocumentRangeFormattingEditProvider
-  implements languages.DocumentRangeFormattingEditProvider {
-  constructor(private _worker: WorkerAccessor) {}
-
-  provideDocumentRangeFormattingEdits(
-    model: editor.IReadOnlyModel,
-    range: Range,
-    options: languages.FormattingOptions,
-  ): PromiseLike<editor.ISingleEditOperation[]> {
-    const resource = model.uri;
-
-    return this._worker(resource).then((worker) =>
-      worker
-        .format(String(resource), fromRange(range), fromFormattingOptions(options))
-        .then((edits) => {
-          if (!edits || edits.length === 0) {
-            return;
-          }
-          return edits.map(toTextEdit);
-        }),
     );
   }
 }

--- a/src/languageFeatures.ts
+++ b/src/languageFeatures.ts
@@ -432,7 +432,7 @@ export class DocumentFormattingEditProvider implements languages.DocumentFormatt
     const resource = model.uri;
 
     return this._worker(resource).then((worker) =>
-      worker.format(String(resource), null, fromFormattingOptions(options)).then((edits) => {
+      worker.format(String(resource), fromFormattingOptions(options)).then((edits) => {
         if (!edits || edits.length === 0) {
           return;
         }

--- a/src/yamlMode.ts
+++ b/src/yamlMode.ts
@@ -62,10 +62,6 @@ export function setupMode(defaults: LanguageServiceDefaultsImpl): void {
       languageId,
       new languageFeatures.DocumentFormattingEditProvider(worker),
     ),
-    languages.registerDocumentRangeFormattingEditProvider(
-      languageId,
-      new languageFeatures.DocumentRangeFormattingEditProvider(worker),
-    ),
     new languageFeatures.DiagnosticsAdapter(languageId, worker, defaults),
     languages.setLanguageConfiguration(languageId, richEditConfiguration),
   );

--- a/src/yamlWorker.ts
+++ b/src/yamlWorker.ts
@@ -57,11 +57,7 @@ export class YAMLWorker {
     return this._languageService.doHover(document, position);
   }
 
-  format(
-    uri: string,
-    range: ls.Range,
-    options: yamlService.CustomFormatterOptions,
-  ): PromiseLike<ls.TextEdit[]> {
+  format(uri: string, options: yamlService.CustomFormatterOptions): PromiseLike<ls.TextEdit[]> {
     const document = this._getTextDocument(uri);
     const textEdits = this._languageService.doFormat(document, options);
     return Promise.resolve(textEdits);


### PR DESCRIPTION
The YAML language service doesn’t support formatting ranges.

In practice this means the “Format Selection” option which does the same as “Format Document” is no longer available in the menu that’s opened when pressing F1.