### PR TITLE
Do some tsconfig cleanups

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,17 +1,15 @@
 {
   "compilerOptions": {
-    "alwaysStrict": true,
     "declaration": true,
     "forceConsistentCasingInFileNames": true,
     "downlevelIteration": true,
+    "lib": ["dom", "es2017"],
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom", "es2017"],
-    "outDir": "./out/esm",
+    "noEmit": true,
     "skipLibCheck": true,
     "sourceMap": true,
     "target": "es6",
     "types": []
-  },
-  "exclude": ["node_modules", "out", "lib", "test"]
+  }
 }


### PR DESCRIPTION
- `alwaysStrict` is unnecessary, because ESM is always strict.
- `noEmit` is enabled, because TypeScript isn’t used to bundle the code.
- `outDir` was removed, because TypeScrtips isn’t used to bundle the code.
- `exclude` was removed, because it’s not necessary.