### PR TITLE
Convert classes to factory functions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -57,6 +57,7 @@ declare module 'monaco-editor/esm/vs/editor/editor.api' {
 
     export interface LanguageServiceDefaults {
       readonly onDidChange: IEvent<LanguageServiceDefaults>;
+      readonly languageId: string;
       readonly diagnosticsOptions: DiagnosticsOptions;
       setDiagnosticsOptions: (options: DiagnosticsOptions) => void;
     }

--- a/src/monaco.contribution.ts
+++ b/src/monaco.contribution.ts
@@ -1,35 +1,36 @@
-import { Emitter, IEvent, languages } from 'monaco-editor/esm/vs/editor/editor.api';
+import { Emitter, languages } from 'monaco-editor/esm/vs/editor/editor.api';
 
 import { setupMode } from './yamlMode';
 
 // --- YAML configuration and defaults ---------
 
-export class LanguageServiceDefaultsImpl implements languages.yaml.LanguageServiceDefaults {
-  private _onDidChange = new Emitter<languages.yaml.LanguageServiceDefaults>();
-  private _diagnosticsOptions: languages.yaml.DiagnosticsOptions;
-  private _languageId: string;
+export function createLanguageServiceDefaults(
+  languageId: string,
+  initialDiagnosticsOptions: languages.yaml.DiagnosticsOptions,
+): languages.yaml.LanguageServiceDefaults {
+  const onDidChange = new Emitter<languages.yaml.LanguageServiceDefaults>();
+  let diagnosticsOptions = initialDiagnosticsOptions;
 
-  constructor(languageId: string, diagnosticsOptions: languages.yaml.DiagnosticsOptions) {
-    this._languageId = languageId;
-    this.setDiagnosticsOptions(diagnosticsOptions);
-  }
+  const languageServiceDefaults: languages.yaml.LanguageServiceDefaults = {
+    get onDidChange() {
+      return onDidChange.event;
+    },
 
-  get onDidChange(): IEvent<languages.yaml.LanguageServiceDefaults> {
-    return this._onDidChange.event;
-  }
+    get languageId() {
+      return languageId;
+    },
 
-  get languageId(): string {
-    return this._languageId;
-  }
+    get diagnosticsOptions() {
+      return diagnosticsOptions;
+    },
 
-  get diagnosticsOptions(): languages.yaml.DiagnosticsOptions {
-    return this._diagnosticsOptions;
-  }
+    setDiagnosticsOptions(options) {
+      diagnosticsOptions = options || {};
+      onDidChange.fire(languageServiceDefaults);
+    },
+  };
 
-  setDiagnosticsOptions(options: languages.yaml.DiagnosticsOptions): void {
-    this._diagnosticsOptions = options || Object.create(null);
-    this._onDidChange.fire(this);
-  }
+  return languageServiceDefaults;
 }
 
 const diagnosticDefault: languages.yaml.DiagnosticsOptions = {
@@ -38,7 +39,7 @@ const diagnosticDefault: languages.yaml.DiagnosticsOptions = {
   enableSchemaRequest: false,
 };
 
-const yamlDefaults = new LanguageServiceDefaultsImpl('yaml', diagnosticDefault);
+const yamlDefaults = createLanguageServiceDefaults('yaml', diagnosticDefault);
 
 // Export API
 function createAPI(): typeof languages.yaml {

--- a/src/workerManager.ts
+++ b/src/workerManager.ts
@@ -1,85 +1,82 @@
-import { editor, IDisposable, Uri } from 'monaco-editor/esm/vs/editor/editor.api';
+import { editor, IDisposable, languages, Uri } from 'monaco-editor/esm/vs/editor/editor.api';
 
-import { LanguageServiceDefaultsImpl } from './monaco.contribution';
 import { YAMLWorker } from './yamlWorker';
+
+export interface WorkerManager extends IDisposable {
+  getLanguageServiceWorker: (...resources: Uri[]) => Promise<YAMLWorker>;
+}
 
 // 2min
 const STOP_WHEN_IDLE_FOR = 2 * 60 * 1000;
 
-export class WorkerManager {
-  private _defaults: LanguageServiceDefaultsImpl;
-  private _idleCheckInterval: number;
-  private _lastUsedTime: number;
-  private _configChangeListener: IDisposable;
+export function createWorkerManager(
+  defaults: languages.yaml.LanguageServiceDefaults,
+): WorkerManager {
+  let worker: editor.MonacoWebWorker<YAMLWorker>;
+  let client: Promise<YAMLWorker>;
+  let lastUsedTime = 0;
 
-  private _worker: editor.MonacoWebWorker<YAMLWorker>;
-  private _client: Promise<YAMLWorker>;
-
-  constructor(defaults: LanguageServiceDefaultsImpl) {
-    this._defaults = defaults;
-    this._worker = null;
-    this._idleCheckInterval = setInterval(() => this._checkIfIdle(), 30 * 1000);
-    this._lastUsedTime = 0;
-    this._configChangeListener = this._defaults.onDidChange(() => this._stopWorker());
-  }
-
-  dispose(): void {
-    clearInterval(this._idleCheckInterval);
-    this._configChangeListener.dispose();
-    this._stopWorker();
-  }
-
-  getLanguageServiceWorker(...resources: Uri[]): Promise<YAMLWorker> {
-    let _client: YAMLWorker;
-    return this._getClient()
-      .then((client) => {
-        _client = client;
-      })
-      .then(() => this._worker.withSyncedResources(resources))
-      .then(() => _client);
-  }
-
-  private _stopWorker(): void {
-    if (this._worker) {
-      this._worker.dispose();
-      this._worker = null;
+  const stopWorker = (): void => {
+    if (worker) {
+      worker.dispose();
+      worker = null;
     }
-    this._client = null;
-  }
+    client = null;
+  };
 
-  private _checkIfIdle(): void {
-    if (!this._worker) {
+  const idleCheckInterval = setInterval(() => {
+    if (!worker) {
       return;
     }
-    const timePassedSinceLastUsed = Date.now() - this._lastUsedTime;
+    const timePassedSinceLastUsed = Date.now() - lastUsedTime;
     if (timePassedSinceLastUsed > STOP_WHEN_IDLE_FOR) {
-      this._stopWorker();
+      stopWorker();
     }
-  }
+  }, 30 * 1000);
 
-  private _getClient(): Promise<YAMLWorker> {
-    this._lastUsedTime = Date.now();
+  const configChangeListener = defaults.onDidChange(() => stopWorker());
 
-    if (!this._client) {
-      this._worker = editor.createWebWorker<YAMLWorker>({
+  const getClient = (): Promise<YAMLWorker> => {
+    lastUsedTime = Date.now();
+
+    if (!client) {
+      worker = editor.createWebWorker<YAMLWorker>({
         // Module that exports the create() method and returns a `YAMLWorker` instance
         moduleId: 'vs/language/yaml/yamlWorker',
 
-        label: this._defaults.languageId,
+        label: defaults.languageId,
 
         // Passed in to the create() method
         createData: {
-          languageSettings: this._defaults.diagnosticsOptions,
-          languageId: this._defaults.languageId,
-          enableSchemaRequest: this._defaults.diagnosticsOptions.enableSchemaRequest,
-          prefix: this._defaults.diagnosticsOptions.prefix,
-          isKubernetes: this._defaults.diagnosticsOptions.isKubernetes,
+          languageSettings: defaults.diagnosticsOptions,
+          languageId: defaults.languageId,
+          enableSchemaRequest: defaults.diagnosticsOptions.enableSchemaRequest,
+          prefix: defaults.diagnosticsOptions.prefix,
+          isKubernetes: defaults.diagnosticsOptions.isKubernetes,
         },
       });
 
-      this._client = this._worker.getProxy();
+      client = worker.getProxy();
     }
 
-    return this._client;
-  }
+    return client;
+  };
+
+  return {
+    dispose() {
+      clearInterval(idleCheckInterval);
+      configChangeListener.dispose();
+      stopWorker();
+    },
+
+    getLanguageServiceWorker(...resources) {
+      let _client: YAMLWorker;
+      return getClient()
+        .then((client) => {
+          _client = client;
+        })
+        .then(() => worker.withSyncedResources(resources))
+        .then(() => _client);
+    },
+  };
 }

--- a/src/yaml.worker.ts
+++ b/src/yaml.worker.ts
@@ -1,8 +1,7 @@
-import * as worker from 'monaco-editor/esm/vs/editor/editor.worker';
+import { initialize } from 'monaco-editor/esm/vs/editor/editor.worker';
 
-import { YAMLWorker } from './yamlWorker';
+import { createYAMLWorker } from './yamlWorker';
 
 self.onmessage = () => {
-  // Ignore the first message
-  worker.initialize((ctx, createData) => new YAMLWorker(ctx, createData));
+  initialize((ctx, createData) => Object.create(createYAMLWorker(ctx, createData)));
 };

--- a/src/yamlWorker.ts
+++ b/src/yamlWorker.ts
@@ -1,6 +1,10 @@
 import { worker } from 'monaco-editor/esm/vs/editor/editor.api';
 import * as ls from 'vscode-languageserver-types';
-import * as yamlService from 'yaml-language-server/lib/esm/languageservice/yamlLanguageService';
+import {
+  CustomFormatterOptions,
+  getLanguageService,
+  LanguageSettings,
+} from 'yaml-language-server/lib/esm/languageservice/yamlLanguageService';
 
 let defaultSchemaRequestService: (url: string) => PromiseLike<string>;
 
@@ -8,90 +12,96 @@ if (typeof fetch !== 'undefined') {
   defaultSchemaRequestService = (url) => fetch(url).then((response) => response.text());
 }
 
-export class YAMLWorker {
-  private _ctx: worker.IWorkerContext;
-  private _languageService: yamlService.LanguageService;
-  private _languageSettings: yamlService.LanguageSettings;
-  private _languageId: string;
-  private _isKubernetes: boolean;
+export interface YAMLWorker {
+  doValidation: (uri: string) => PromiseLike<ls.Diagnostic[]>;
 
-  constructor(ctx: worker.IWorkerContext, createData: ICreateData) {
-    const prefix = createData.prefix || '';
-    const service = (url: string): PromiseLike<string> =>
-      defaultSchemaRequestService(`${prefix}${url}`);
-    this._ctx = ctx;
-    this._languageSettings = createData.languageSettings;
-    this._languageId = createData.languageId;
-    this._languageService = yamlService.getLanguageService(
-      createData.enableSchemaRequest && service,
-      null,
-      [],
-    );
-    this._isKubernetes = createData.isKubernetes || false;
-    this._languageService.configure({
-      ...this._languageSettings,
-      hover: true,
-      isKubernetes: this._isKubernetes,
-    });
-  }
+  doComplete: (uri: string, position: ls.Position) => PromiseLike<ls.CompletionList>;
 
-  doValidation(uri: string): PromiseLike<ls.Diagnostic[]> {
-    const document = this._getTextDocument(uri);
-    if (document) {
-      return this._languageService.doValidation(document, this._isKubernetes);
-    }
-    return Promise.resolve([]);
-  }
+  doResolve: (item: ls.CompletionItem) => PromiseLike<ls.CompletionItem>;
 
-  doComplete(uri: string, position: ls.Position): PromiseLike<ls.CompletionList> {
-    const document = this._getTextDocument(uri);
-    return this._languageService.doComplete(document, position, this._isKubernetes);
-  }
+  doHover: (uri: string, position: ls.Position) => PromiseLike<ls.Hover>;
 
-  doResolve(item: ls.CompletionItem): PromiseLike<ls.CompletionItem> {
-    return this._languageService.doResolve(item);
-  }
+  format: (uri: string, options: CustomFormatterOptions) => PromiseLike<ls.TextEdit[]>;
 
-  doHover(uri: string, position: ls.Position): PromiseLike<ls.Hover> {
-    const document = this._getTextDocument(uri);
-    return this._languageService.doHover(document, position);
-  }
+  resetSchema: (uri: string) => PromiseLike<boolean>;
 
-  format(uri: string, options: yamlService.CustomFormatterOptions): PromiseLike<ls.TextEdit[]> {
-    const document = this._getTextDocument(uri);
-    const textEdits = this._languageService.doFormat(document, options);
-    return Promise.resolve(textEdits);
-  }
+  findDocumentSymbols: (uri: string) => PromiseLike<ls.DocumentSymbol[]>;
+}
 
-  resetSchema(uri: string): PromiseLike<boolean> {
-    return Promise.resolve(this._languageService.resetSchema(uri));
-  }
+export function createYAMLWorker(
+  ctx: worker.IWorkerContext,
+  {
+    enableSchemaRequest,
+    isKubernetes = false,
+    languageId,
+    languageSettings,
+    prefix = '',
+  }: ICreateData,
+): YAMLWorker {
+  const service = (url: string): PromiseLike<string> =>
+    defaultSchemaRequestService(`${prefix}${url}`);
+  const languageService = getLanguageService(enableSchemaRequest && service, null, []);
+  languageService.configure({
+    ...languageSettings,
+    hover: true,
+    isKubernetes,
+  });
 
-  findDocumentSymbols(uri: string): PromiseLike<ls.DocumentSymbol[]> {
-    const document = this._getTextDocument(uri);
-    const symbols = this._languageService.findDocumentSymbols2(document);
-    return Promise.resolve(symbols);
-  }
-
-  private _getTextDocument(uri: string): ls.TextDocument {
-    const models = this._ctx.getMirrorModels();
+  const getTextDocument = (uri: string): ls.TextDocument => {
+    const models = ctx.getMirrorModels();
     for (const model of models) {
       if (String(model.uri) === uri) {
-        return ls.TextDocument.create(uri, this._languageId, model.version, model.getValue());
+        return ls.TextDocument.create(uri, languageId, model.version, model.getValue());
       }
     }
     return null;
-  }
+  };
+
+  return {
+    doValidation(uri) {
+      const document = getTextDocument(uri);
+      if (document) {
+        return languageService.doValidation(document, isKubernetes);
+      }
+      return Promise.resolve([]);
+    },
+
+    doComplete(uri, position) {
+      const document = getTextDocument(uri);
+      return languageService.doComplete(document, position, isKubernetes);
+    },
+
+    doResolve(item) {
+      return languageService.doResolve(item);
+    },
+
+    doHover(uri, position) {
+      const document = getTextDocument(uri);
+      return languageService.doHover(document, position);
+    },
+
+    format(uri, options) {
+      const document = getTextDocument(uri);
+      const textEdits = languageService.doFormat(document, options);
+      return Promise.resolve(textEdits);
+    },
+
+    resetSchema(uri) {
+      return Promise.resolve(languageService.resetSchema(uri));
+    },
+
+    findDocumentSymbols(uri) {
+      const document = getTextDocument(uri);
+      const symbols = languageService.findDocumentSymbols2(document);
+      return Promise.resolve(symbols);
+    },
+  };
 }
 
 export interface ICreateData {
   languageId: string;
-  languageSettings: yamlService.LanguageSettings;
+  languageSettings: LanguageSettings;
   enableSchemaRequest: boolean;
   prefix?: string;
   isKubernetes?: boolean;
-}
-
-export function create(ctx: worker.IWorkerContext, createData: ICreateData): YAMLWorker {
-  return new YAMLWorker(ctx, createData);
 }


### PR DESCRIPTION
I’m not a fan of using classes in JavaScript. No actual logic has been changed.

TypeScript is better at inferring types when using simple functions and objects instead of classes. As a result many type annotations have now been removed without impacting type safety.

Some other benefits are this can be minified better and private fields are now truly private variables.