### PR TITLE
Convert promise chains to async/await

### DIFF
--- a/src/workerManager.ts
+++ b/src/workerManager.ts
@@ -69,14 +69,10 @@ export function createWorkerManager(
       stopWorker();
     },
 
-    getLanguageServiceWorker(...resources) {
-      let _client: YAMLWorker;
-      return getClient()
-        .then((client) => {
-          _client = client;
-        })
-        .then(() => worker.withSyncedResources(resources))
-        .then(() => _client);
+    async getLanguageServiceWorker(...resources) {
+      const client = await getClient();
+      await worker.withSyncedResources(resources);
+      return client;
     },
   };
 }


### PR DESCRIPTION
I don’t **think** monaco editor still supports browsers that don’t support async/await. I might be wrong though. `monaco-json` also uses async/await, but its transpiled.