### PR TITLE
Automate publishing to npm

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,6 +7,15 @@ on:
     tags: ['*']
 
 jobs:
+  eslint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with: { node-version: 16 }
+      - run: npm ci
+      - run: npx eslint .
+
   pack:
     runs-on: ubuntu-latest
     steps:
@@ -16,14 +25,14 @@ jobs:
       - run: npm ci
       - run: npm pack
 
-  lint:
+  prettier:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with: { node-version: 16 }
       - run: npm ci
-      - run: npm run lint
+      - run: npx prettier --check .
 
   tsc:
     runs-on: ubuntu-latest
@@ -33,3 +42,15 @@ jobs:
         with: { node-version: 16 }
       - run: npm ci
       - run: npx tsc
+
+  release:
+    runs-on: ubuntu-latest
+    needs: [eslint, pack, prettier, tsc]
+    if: startsWith(github.ref, 'refs/tags/')
+    steps:
+      - uses: actions/setup-node@v2
+        with: { node-version: 16 }
+      - run: npm ci
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -5,8 +5,7 @@
   "homepage": "https://monaco-yaml.js.org",
   "scripts": {
     "prepack": "node build.js",
-    "prepare": "husky install",
-    "lint": "eslint . && prettier --check ."
+    "prepare": "husky install"
   },
   "main": "./lib/esm/monaco.contribution.js",
   "module": "./lib/esm/monaco.contribution.js",


### PR DESCRIPTION
Also the `lint` job has been split into `eslint` and `prettier`.

Closes #6