### PR TITLE
Fix publishing

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -48,6 +48,7 @@ jobs:
     needs: [eslint, pack, prettier, tsc]
     if: startsWith(github.ref, 'refs/tags/')
     steps:
+      - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with: { node-version: 16 }
       - run: npm ci


### PR DESCRIPTION
Add the `actions/checkout` action before publishing.

I published 3.1.0 manually, because https://github.com/remcohaszing/monaco-yaml/runs/3434405875 failed.