### PR TITLE
Remove logic for unloading the language

### DIFF
--- a/src/workerManager.ts
+++ b/src/workerManager.ts
@@ -1,40 +1,29 @@
-import { editor, IDisposable, languages, Uri } from 'monaco-editor/esm/vs/editor/editor.api';
+import { editor, languages } from 'monaco-editor/esm/vs/editor/editor.api';
 
+import { WorkerAccessor } from './languageFeatures';
 import { YAMLWorker } from './yamlWorker';
-
-export interface WorkerManager extends IDisposable {
-  getLanguageServiceWorker: (...resources: Uri[]) => Promise<YAMLWorker>;
-}
 
 // 2min
 const STOP_WHEN_IDLE_FOR = 2 * 60 * 1000;
 
 export function createWorkerManager(
   defaults: languages.yaml.LanguageServiceDefaults,
-): WorkerManager {
+): WorkerAccessor {
   let worker: editor.MonacoWebWorker<YAMLWorker>;
   let client: Promise<YAMLWorker>;
   let lastUsedTime = 0;
 
-  const stopWorker = (): void => {
-    if (worker) {
-      worker.dispose();
-      worker = null;
-    }
-    client = null;
-  };
-
-  const idleCheckInterval = setInterval(() => {
+  setInterval(() => {
     if (!worker) {
       return;
     }
     const timePassedSinceLastUsed = Date.now() - lastUsedTime;
     if (timePassedSinceLastUsed > STOP_WHEN_IDLE_FOR) {
-      stopWorker();
+      worker.dispose();
+      worker = undefined;
+      client = undefined;
     }
   }, 30 * 1000);
-
-  const configChangeListener = defaults.onDidChange(() => stopWorker());
 
   const getClient = (): Promise<YAMLWorker> => {
     lastUsedTime = Date.now();
@@ -62,17 +51,9 @@ export function createWorkerManager(
     return client;
   };
 
-  return {
-    dispose() {
-      clearInterval(idleCheckInterval);
-      configChangeListener.dispose();
-      stopWorker();
-    },
-
-    async getLanguageServiceWorker(...resources) {
-      const client = await getClient();
-      await worker.withSyncedResources(resources);
-      return client;
-    },
+  return async (...resources) => {
+    const client = await getClient();
+    await worker.withSyncedResources(resources);
+    return client;
   };
 }

--- a/src/yamlMode.ts
+++ b/src/yamlMode.ts
@@ -1,4 +1,4 @@
-import { IDisposable, languages, Uri } from 'monaco-editor/esm/vs/editor/editor.api';
+import { languages } from 'monaco-editor/esm/vs/editor/editor.api';
 
 import {
   createCompletionItemProvider,
@@ -7,10 +7,8 @@ import {
   createDocumentSymbolProvider,
   createHoverProvider,
   createLinkProvider,
-  WorkerAccessor,
 } from './languageFeatures';
 import { createWorkerManager } from './workerManager';
-import { YAMLWorker } from './yamlWorker';
 
 const richEditConfiguration: languages.LanguageConfiguration = {
   comments: {
@@ -45,26 +43,18 @@ const richEditConfiguration: languages.LanguageConfiguration = {
 };
 
 export function setupMode(defaults: languages.yaml.LanguageServiceDefaults): void {
-  const disposables: IDisposable[] = [];
-
-  const client = createWorkerManager(defaults);
-  disposables.push(client);
-
-  const worker: WorkerAccessor = (...uris: Uri[]): Promise<YAMLWorker> =>
-    client.getLanguageServiceWorker(...uris);
+  const worker = createWorkerManager(defaults);
 
   const { languageId } = defaults;
 
-  disposables.push(
-    languages.registerCompletionItemProvider(languageId, createCompletionItemProvider(worker)),
-    languages.registerHoverProvider(languageId, createHoverProvider(worker)),
-    languages.registerDocumentSymbolProvider(languageId, createDocumentSymbolProvider(worker)),
-    languages.registerDocumentFormattingEditProvider(
-      languageId,
-      createDocumentFormattingEditProvider(worker),
-    ),
-    languages.registerLinkProvider(languageId, createLinkProvider(worker)),
-    createDiagnosticsAdapter(languageId, worker, defaults),
-    languages.setLanguageConfiguration(languageId, richEditConfiguration),
+  languages.registerCompletionItemProvider(languageId, createCompletionItemProvider(worker));
+  languages.registerHoverProvider(languageId, createHoverProvider(worker));
+  languages.registerDocumentSymbolProvider(languageId, createDocumentSymbolProvider(worker));
+  languages.registerDocumentFormattingEditProvider(
+    languageId,
+    createDocumentFormattingEditProvider(worker),
   );
+  languages.registerLinkProvider(languageId, createLinkProvider(worker));
+  createDiagnosticsAdapter(languageId, worker, defaults);
+  languages.setLanguageConfiguration(languageId, richEditConfiguration);
 }


### PR DESCRIPTION
It’s not supported in `monaco-editor` nor is it planned.

See https://github.com/microsoft/monaco-editor/issues/2642