### PR TITLE
Apply various stylistic fixes

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -1,24 +1,18 @@
-extends: remcohaszing
+extends:
+  - remcohaszing
+  - remcohaszing/typechecking
 rules:
-  class-methods-use-this: off
-  max-classes-per-file: off
-  no-console: off
   no-restricted-globals: off
-  no-underscore-dangle: off
-  no-useless-constructor: off
 
-  '@typescript-eslint/naming-convention': off
-  '@typescript-eslint/no-parameter-properties': off
+  '@typescript-eslint/no-misused-promises': off
   '@typescript-eslint/no-shadow': off
-  '@typescript-eslint/prefer-optional-chain': off
+  '@typescript-eslint/no-unnecessary-condition': off
 
   import/no-extraneous-dependencies: off
   import/no-unresolved: off
-  import/no-webpack-loader-syntax: off
 
   jsdoc/require-jsdoc: off
 
   node/no-extraneous-import: off
-  node/no-unpublished-import: off
   node/no-unsupported-features/es-syntax: off
   node/no-unsupported-features/node-builtins: off

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ npm install monaco-yaml
 
 Import `monaco-yaml` and configure it before an editor instance is created.
 
-```ts
+```typescript
 import { editor, Uri } from 'monaco-editor';
 import { setDiagnosticsOptions } from 'monaco-yaml';
 

--- a/build.js
+++ b/build.js
@@ -66,6 +66,7 @@ fs.rm(join(__dirname, 'lib'), { force: true, recursive: true })
     }),
   )
   .catch((error) => {
+    // eslint-disable-next-line no-console
     console.error(error);
     process.exit(1);
   });

--- a/examples/demo/src/index.ts
+++ b/examples/demo/src/index.ts
@@ -121,7 +121,7 @@ fetch('https://www.schemastore.org/api/json/catalog.json').then(async (response)
   if (!response.ok) {
     return;
   }
-  const catalog: JSONSchemaForSchemaStoreOrgCatalogFiles = await response.json();
+  const catalog = (await response.json()) as JSONSchemaForSchemaStoreOrgCatalogFiles;
   const schemas = [defaultSchema];
   catalog.schemas.sort((a, b) => a.name.localeCompare(b.name));
   for (const { fileMatch, name, url } of catalog.schemas) {

--- a/examples/demo/src/types.d.ts
+++ b/examples/demo/src/types.d.ts
@@ -1,4 +1,30 @@
+declare module 'monaco-editor/esm/vs/base/common/cancellation' {
+  export enum CancellationToken {
+    None,
+  }
+}
+
+declare module 'monaco-editor/esm/vs/editor/contrib/documentSymbols/documentSymbols' {
+  import { ITextModel, languages } from 'monaco-editor';
+  // eslint-disable-next-line import/order
+  import { CancellationToken } from 'monaco-editor/esm/vs/base/common/cancellation';
+
+  export function getDocumentSymbols(
+    model: ITextModel,
+    flat: boolean,
+    token: CancellationToken,
+  ): Promise<languages.DocumentSymbol[]>;
+}
+
+declare module 'monaco-editor/esm/vs/editor/editor.worker' {
+  import { worker } from 'monaco-editor/esm/vs/editor/editor.api';
+
+  export function initialize(
+    fn: (ctx: worker.IWorkerContext, createData: unknown) => unknown,
+  ): void;
+}
+
 declare module '*.json' {
-  declare const uri;
+  declare const uri: string;
   export default uri;
 }

--- a/src/fillers/vscode-nls.ts
+++ b/src/fillers/vscode-nls.ts
@@ -16,7 +16,7 @@ export type LoadFunc = (file?: string) => LocalizeFunc;
 function format(message: string, args: string[]): string {
   return args.length === 0
     ? message
-    : message.replace(/{(\d+)}/g, (match, rest) => {
+    : message.replace(/{(\d+)}/g, (match, rest: number[]) => {
         const [index] = rest;
         return typeof args[index] === 'undefined' ? match : args[index];
       });

--- a/src/yaml.worker.ts
+++ b/src/yaml.worker.ts
@@ -1,7 +1,7 @@
 import { initialize } from 'monaco-editor/esm/vs/editor/editor.worker';
 
-import { createYAMLWorker } from './yamlWorker';
+import { createYAMLWorker, ICreateData } from './yamlWorker';
 
 self.onmessage = () => {
-  initialize((ctx, createData) => Object.create(createYAMLWorker(ctx, createData)));
+  initialize((ctx, createData: ICreateData) => Object.create(createYAMLWorker(ctx, createData)));
 };


### PR DESCRIPTION
- ESLint config `remcohaszing/typechecking` is extended.
- Various previously disabled ESLint rules have now been enabled.
- Various `any` types have been fixed.
- Removed useless type check of diagnostic code.
- The diagnostics adapter listener has been turned into an actual map.