### PR TITLE
Restore ability to change options after loading

### DIFF
--- a/src/workerManager.ts
+++ b/src/workerManager.ts
@@ -13,17 +13,26 @@ export function createWorkerManager(
   let client: Promise<YAMLWorker>;
   let lastUsedTime = 0;
 
+  const stopWorker = (): void => {
+    if (worker) {
+      worker.dispose();
+      worker = undefined;
+    }
+    client = undefined;
+  };
+
   setInterval(() => {
     if (!worker) {
       return;
     }
     const timePassedSinceLastUsed = Date.now() - lastUsedTime;
     if (timePassedSinceLastUsed > STOP_WHEN_IDLE_FOR) {
-      worker.dispose();
-      worker = undefined;
-      client = undefined;
+      stopWorker();
     }
   }, 30 * 1000);
+
+  // This is necessary to have updated language options take effect (e.g. schema changes)
+  defaults.onDidChange(() => stopWorker());
 
   const getClient = (): Promise<YAMLWorker> => {
     lastUsedTime = Date.now();


### PR DESCRIPTION
Restore `onDidChange` handler which is fired when `setDiagnosticsOptions` is called. This handler restarts the worker with the new settings.

We previously used this handler in this library. [`monaco-json` does something similar](https://github.com/microsoft/monaco-json/blob/c8a5be4ee1be41043b4c324360a88ddc6a12b254/src/workerManager.ts#L26) as well.

Fixes: https://github.com/remcohaszing/monaco-yaml/issues/105