### PR TITLE
Fix crashes from null model

### DIFF
--- a/src/languageFeatures.ts
+++ b/src/languageFeatures.ts
@@ -62,7 +62,9 @@ export function createDiagnosticsAdapter(
     const diagnostics = await worker.doValidation(String(resource));
     const markers = diagnostics.map(toDiagnostics);
     const model = editor.getModel(resource);
-    if (model.getModeId() === languageId) {
+    // Return value from getModel can be null if model not found
+    // (e.g. if user navigates away from editor)
+    if (model && model.getModeId() === languageId) {
       editor.setModelMarkers(model, languageId, markers);
     }
   };


### PR DESCRIPTION
`editor.getModel(resource)` can return null at times - e.g. if the user navigated away from the editor in a React app. This checks for the model existing first before attempting to call `getModeId`. 

Prior art: [`monaco-json` does this as well](https://github.com/microsoft/monaco-json/blob/c8a5be4ee1be41043b4c324360a88ddc6a12b254/src/languageFeatures.ts#L117)

Fixes: https://github.com/remcohaszing/monaco-yaml/issues/106

FWIW the typing for `getModel` returns `ITextModel | null` - not sure why this is not impacting the type checking of the code in current state.