### PR TITLE
Extract languageId into constants

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,1 @@
+export const languageId = 'yaml';

--- a/src/monaco.contribution.ts
+++ b/src/monaco.contribution.ts
@@ -1,11 +1,11 @@
 import { Emitter, languages } from 'monaco-editor/esm/vs/editor/editor.api';
 
+import { languageId } from './constants';
 import { setupMode } from './yamlMode';
 
 // --- YAML configuration and defaults ---------
 
 export function createLanguageServiceDefaults(
-  languageId: string,
   initialDiagnosticsOptions: languages.yaml.DiagnosticsOptions,
 ): languages.yaml.LanguageServiceDefaults {
   const onDidChange = new Emitter<languages.yaml.LanguageServiceDefaults>();
@@ -39,7 +39,7 @@ const diagnosticDefault: languages.yaml.DiagnosticsOptions = {
   enableSchemaRequest: false,
 };
 
-const yamlDefaults = createLanguageServiceDefaults('yaml', diagnosticDefault);
+const yamlDefaults = createLanguageServiceDefaults(diagnosticDefault);
 
 // Export API
 function createAPI(): typeof languages.yaml {
@@ -52,7 +52,7 @@ languages.yaml = createAPI();
 // --- Registration to monaco editor ---
 
 languages.register({
-  id: 'yaml',
+  id: languageId,
   extensions: ['.yaml', '.yml'],
   aliases: ['YAML', 'yaml', 'YML', 'yml'],
   mimetypes: ['application/x-yaml'],

--- a/src/workerManager.ts
+++ b/src/workerManager.ts
@@ -47,7 +47,6 @@ export function createWorkerManager(
         // Passed in to the create() method
         createData: {
           languageSettings: defaults.diagnosticsOptions,
-          languageId: defaults.languageId,
           enableSchemaRequest: defaults.diagnosticsOptions.enableSchemaRequest,
           prefix: defaults.diagnosticsOptions.prefix,
           isKubernetes: defaults.diagnosticsOptions.isKubernetes,

--- a/src/yamlMode.ts
+++ b/src/yamlMode.ts
@@ -1,5 +1,6 @@
 import { languages } from 'monaco-editor/esm/vs/editor/editor.api';
 
+import { languageId } from './constants';
 import {
   createCompletionItemProvider,
   createDiagnosticsAdapter,
@@ -45,8 +46,6 @@ const richEditConfiguration: languages.LanguageConfiguration = {
 export function setupMode(defaults: languages.yaml.LanguageServiceDefaults): void {
   const worker = createWorkerManager(defaults);
 
-  const { languageId } = defaults;
-
   languages.registerCompletionItemProvider(languageId, createCompletionItemProvider(worker));
   languages.registerHoverProvider(languageId, createHoverProvider(worker));
   languages.registerDocumentSymbolProvider(languageId, createDocumentSymbolProvider(worker));
@@ -55,6 +54,6 @@ export function setupMode(defaults: languages.yaml.LanguageServiceDefaults): voi
     createDocumentFormattingEditProvider(worker),
   );
   languages.registerLinkProvider(languageId, createLinkProvider(worker));
-  createDiagnosticsAdapter(languageId, worker, defaults);
+  createDiagnosticsAdapter(worker, defaults);
   languages.setLanguageConfiguration(languageId, richEditConfiguration);
 }

--- a/src/yamlWorker.ts
+++ b/src/yamlWorker.ts
@@ -8,6 +8,8 @@ import {
   LanguageSettings,
 } from 'yaml-language-server/lib/esm/languageservice/yamlLanguageService';
 
+import { languageId } from './constants';
+
 let defaultSchemaRequestService: (url: string) => Promise<string>;
 
 if (typeof fetch !== 'undefined') {
@@ -32,13 +34,7 @@ export interface YAMLWorker {
 
 export function createYAMLWorker(
   ctx: worker.IWorkerContext,
-  {
-    enableSchemaRequest,
-    isKubernetes = false,
-    languageId,
-    languageSettings,
-    prefix = '',
-  }: ICreateData,
+  { enableSchemaRequest, isKubernetes = false, languageSettings, prefix = '' }: ICreateData,
 ): YAMLWorker {
   const service = (url: string): Promise<string> => defaultSchemaRequestService(`${prefix}${url}`);
   const languageService = getLanguageService(enableSchemaRequest && service, null, null, null);
@@ -99,7 +95,6 @@ export function createYAMLWorker(
 }
 
 export interface ICreateData {
-  languageId: string;
   languageSettings: LanguageSettings;
   enableSchemaRequest: boolean;
   prefix?: string;


### PR DESCRIPTION
It was defined once, but it was passed into various functions. This added unnecessary complexity.

It is now defined in a constants file, which is imported where necessary.