### PR TITLE
Update monaco to 0.30

### DIFF
--- a/examples/demo/package.json
+++ b/examples/demo/package.json
@@ -13,7 +13,7 @@
     "css-minimizer-webpack-plugin": "^3.0.0",
     "html-webpack-plugin": "^5.0.0",
     "mini-css-extract-plugin": "^2.0.0",
-    "monaco-editor": "^0.27.0",
+    "monaco-editor": "^0.30.0",
     "monaco-yaml": "file:../..",
     "ts-loader": "^9.0.0",
     "typescript": "^4.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,13 +28,13 @@
         "eslint-config-remcohaszing": "^3.0.0",
         "husky": "^7.0.0",
         "lint-staged": "^11.0.0",
-        "monaco-editor": "^0.27.0",
+        "monaco-editor": "^0.30.0",
         "type-fest": "^2.0.0",
         "typescript": "^4.0.0",
         "yaml-language-server": "^0.22.0"
       },
       "peerDependencies": {
-        "monaco-editor": ">=0.22"
+        "monaco-editor": ">=0.30"
       }
     },
     "examples/demo": {
@@ -46,7 +46,7 @@
         "css-minimizer-webpack-plugin": "^3.0.0",
         "html-webpack-plugin": "^5.0.0",
         "mini-css-extract-plugin": "^2.0.0",
-        "monaco-editor": "^0.27.0",
+        "monaco-editor": "^0.30.0",
         "monaco-yaml": "file:../..",
         "ts-loader": "^9.0.0",
         "typescript": "^4.0.0",
@@ -5400,9 +5400,9 @@
       }
     },
     "node_modules/monaco-editor": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.27.0.tgz",
-      "integrity": "sha512-UhwP78Wb8w0ZSYoKXQNTV/0CHObp6NS3nCt51QfKE6sKyBo5PBsvuDOHoI2ooBakc6uIwByRLHVeT7+yXQe2fQ=="
+      "version": "0.30.1",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.30.1.tgz",
+      "integrity": "sha512-B/y4+b2O5G2gjuxIFtCE2EkM17R2NM7/3F8x0qcPsqy4V83bitJTIO4TIeZpYlzu/xy6INiY/+84BEm6+7Cmzg=="
     },
     "node_modules/monaco-yaml": {
       "resolved": "",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "yaml-language-server-parser": "^0.1.0"
   },
   "peerDependencies": {
-    "monaco-editor": ">=0.22"
+    "monaco-editor": ">=0.30"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^4.0.0",
@@ -57,7 +57,7 @@
     "eslint-config-remcohaszing": "^3.0.0",
     "husky": "^7.0.0",
     "lint-staged": "^11.0.0",
-    "monaco-editor": "^0.27.0",
+    "monaco-editor": "^0.30.0",
     "type-fest": "^2.0.0",
     "typescript": "^4.0.0",
     "yaml-language-server": "^0.22.0"

--- a/src/languageFeatures.ts
+++ b/src/languageFeatures.ts
@@ -63,13 +63,13 @@ export function createDiagnosticsAdapter(
     const model = editor.getModel(resource);
     // Return value from getModel can be null if model not found
     // (e.g. if user navigates away from editor)
-    if (model && model.getModeId() === languageId) {
+    if (model && model.getLanguageId() === languageId) {
       editor.setModelMarkers(model, languageId, markers);
     }
   };
 
   const onModelAdd = (model: editor.IModel): void => {
-    if (model.getModeId() !== languageId) {
+    if (model.getLanguageId() !== languageId) {
       return;
     }
 
@@ -107,7 +107,7 @@ export function createDiagnosticsAdapter(
   });
   defaults.onDidChange(() => {
     for (const model of editor.getModels()) {
-      if (model.getModeId() === languageId) {
+      if (model.getLanguageId() === languageId) {
         onModelRemoved(model);
         onModelAdd(model);
       }


### PR DESCRIPTION
In v0.30, Monaco introduced a [breaking change](https://github.com/microsoft/monaco-editor/blob/main/CHANGELOG.md#0300-04112021) by renaming `ITextModel.getModeId` into `ITextModel.getLanguageId`.

This PR updates the required version of `monaco` to `>= 30` and update the calls to `getModeId` to `getLanguageId`.

fix #131