### PR TITLE
Expose document symbol detail

### DIFF
--- a/src/languageFeatures.ts
+++ b/src/languageFeatures.ts
@@ -341,7 +341,7 @@ function toSymbolKind(kind: ls.SymbolKind): languages.SymbolKind {
 
 function toDocumentSymbol(item: ls.DocumentSymbol): languages.DocumentSymbol {
   return {
-    detail: '',
+    detail: item.detail,
     range: toRange(item.range),
     name: item.name,
     kind: toSymbolKind(item.kind),


### PR DESCRIPTION
Proposed fix for https://github.com/remcohaszing/monaco-yaml/issues/137

Cloned, installed and built with npm pack (prepack didn't work for me).