### PR TITLE
Fix a small type issue

### DIFF
--- a/src/languageFeatures.ts
+++ b/src/languageFeatures.ts
@@ -140,7 +140,7 @@ function toRange(range: ls.Range): Range {
   );
 }
 
-function toCompletionItemKind(kind: languages.CompletionItemKind): languages.CompletionItemKind {
+function toCompletionItemKind(kind: ls.CompletionItemKind): languages.CompletionItemKind {
   const mItemKind = languages.CompletionItemKind;
 
   switch (kind) {


### PR DESCRIPTION
The language server completion kind and monaco completion kind are compatible by coincidence, not by definition.