### PR TITLE
Use extensions for directly importing files

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -8,6 +8,7 @@ rules:
   '@typescript-eslint/no-shadow': off
   '@typescript-eslint/no-unnecessary-condition': off
 
+  import/extensions: off
   import/no-extraneous-dependencies: off
   import/no-unresolved: off
 

--- a/build.js
+++ b/build.js
@@ -22,20 +22,8 @@ fs.rm(join(__dirname, 'lib'), { force: true, recursive: true })
           setup({ onResolve }) {
             // The yaml language service only imports re-exports of vscode-languageserver-types from
             // vscode-languageserver.
-            onResolve({ filter: /^vscode-languageserver-textdocument$/ }, () => ({
-              path: 'vscode-languageserver-textdocument/lib/esm/main.js',
-              external: true,
-            }));
-            // The yaml language service only imports re-exports of vscode-languageserver-types from
-            // vscode-languageserver.
-            onResolve({ filter: /^vscode-languageserver(\/node)?$/ }, () => ({
-              path: 'vscode-languageserver-types/lib/esm/main.js',
-              external: true,
-            }));
-            // The yaml language service only imports re-exports of vscode-languageserver-types from
-            // vscode-languageserver.
-            onResolve({ filter: /^vscode-languageserver-(protocol|types)$/ }, () => ({
-              path: 'vscode-languageserver-types/lib/esm/main.js',
+            onResolve({ filter: /^vscode-languageserver(\/node|-protocol)?$/ }, () => ({
+              path: 'vscode-languageserver-types',
               external: true,
             }));
             // The yaml language service uses path. We can stub it using path-browserify.
@@ -45,8 +33,8 @@ fs.rm(join(__dirname, 'lib'), { force: true, recursive: true })
             }));
             // The main prettier entry point contains all of Prettier.
             // The standalone bundle is smaller and works fine for us.
-            onResolve({ filter: /^prettier$/ }, () => ({
-              path: 'prettier/standalone',
+            onResolve({ filter: /^prettier/ }, ({ path }) => ({
+              path: path === 'prettier' ? 'prettier/standalone.js' : `${path}.js`,
               external: true,
             }));
             // This tiny filler implementation serves all our needs.

--- a/examples/demo/src/types.d.ts
+++ b/examples/demo/src/types.d.ts
@@ -15,7 +15,7 @@ declare module 'monaco-editor/esm/vs/editor/contrib/documentSymbols/documentSymb
   ): Promise<languages.DocumentSymbol[]>;
 }
 
-declare module 'monaco-editor/esm/vs/editor/editor.worker' {
+declare module 'monaco-editor/esm/vs/editor/editor.worker.js' {
   import { worker } from 'monaco-editor/esm/vs/editor/editor.api';
 
   export function initialize(

--- a/examples/monaco-editor-webpack-plugin/editor.js
+++ b/examples/monaco-editor-webpack-plugin/editor.js
@@ -1,7 +1,5 @@
-// eslint-disable-next-line import/extensions
 import * as monaco from 'monaco-editor/esm/vs/editor/editor.api.js';
 
-// eslint-disable-next-line import/extensions
 export { editor } from 'monaco-editor/esm/vs/editor/editor.api.js';
 export { setDiagnosticsOptions } from 'monaco-yaml';
 export default monaco;

--- a/examples/monaco-editor-webpack-plugin/index.js
+++ b/examples/monaco-editor-webpack-plugin/index.js
@@ -4,7 +4,6 @@ boolean: true
 `;
 
 async function create() {
-  // eslint-disable-next-line import/extensions
   const monaco = await import('./main.js');
 
   monaco.editor.create(document.querySelector('.editor'), {

--- a/src/languageFeatures.ts
+++ b/src/languageFeatures.ts
@@ -6,9 +6,9 @@ import {
   Position,
   Range,
   Uri,
-} from 'monaco-editor/esm/vs/editor/editor.api';
+} from 'monaco-editor/esm/vs/editor/editor.api.js';
 import * as ls from 'vscode-languageserver-types';
-import { CustomFormatterOptions } from 'yaml-language-server/lib/esm/languageservice/yamlLanguageService';
+import { CustomFormatterOptions } from 'yaml-language-server/lib/esm/languageservice/yamlLanguageService.js';
 
 import { languageId } from './constants';
 import { YAMLWorker } from './yamlWorker';

--- a/src/monaco.contribution.ts
+++ b/src/monaco.contribution.ts
@@ -1,4 +1,4 @@
-import { Emitter, languages } from 'monaco-editor/esm/vs/editor/editor.api';
+import { Emitter, languages } from 'monaco-editor/esm/vs/editor/editor.api.js';
 
 import { languageId } from './constants';
 import { setupMode } from './yamlMode';

--- a/src/workerManager.ts
+++ b/src/workerManager.ts
@@ -1,4 +1,4 @@
-import { editor, languages } from 'monaco-editor/esm/vs/editor/editor.api';
+import { editor, languages } from 'monaco-editor/esm/vs/editor/editor.api.js';
 
 import { WorkerAccessor } from './languageFeatures';
 import { YAMLWorker } from './yamlWorker';

--- a/src/yaml.worker.ts
+++ b/src/yaml.worker.ts
@@ -1,4 +1,4 @@
-import { initialize } from 'monaco-editor/esm/vs/editor/editor.worker';
+import { initialize } from 'monaco-editor/esm/vs/editor/editor.worker.js';
 
 import { createYAMLWorker, ICreateData } from './yamlWorker';
 

--- a/src/yamlMode.ts
+++ b/src/yamlMode.ts
@@ -1,4 +1,4 @@
-import { languages } from 'monaco-editor/esm/vs/editor/editor.api';
+import { languages } from 'monaco-editor/esm/vs/editor/editor.api.js';
 
 import { languageId } from './constants';
 import {

--- a/src/yamlWorker.ts
+++ b/src/yamlWorker.ts
@@ -1,4 +1,4 @@
-import { worker } from 'monaco-editor/esm/vs/editor/editor.api';
+import { worker } from 'monaco-editor/esm/vs/editor/editor.api.js';
 import { Promisable } from 'type-fest';
 import { TextDocument } from 'vscode-languageserver-textdocument';
 import * as ls from 'vscode-languageserver-types';
@@ -6,7 +6,7 @@ import {
   CustomFormatterOptions,
   getLanguageService,
   LanguageSettings,
-} from 'yaml-language-server/lib/esm/languageservice/yamlLanguageService';
+} from 'yaml-language-server/lib/esm/languageservice/yamlLanguageService.js';
 
 import { languageId } from './constants';
 


### PR DESCRIPTION
For better ESM compatibility, this adds a file extension for nested package files.

This also removes the nested special handling of `vscode-languageserver-types` and `vscode-languageserver-document`
imports. This is unnecessary, because they use the `"module"` field in `package.json`.