### PR TITLE
Add support for document symbol details

### DIFF
--- a/examples/demo/src/index.ts
+++ b/examples/demo/src/index.ts
@@ -184,6 +184,7 @@ ed.onDidChangeCursorPosition(async (event) => {
     breadcrumb.setAttribute('role', 'button');
     breadcrumb.classList.add('breadcrumb');
     breadcrumb.textContent = symbol.name;
+    breadcrumb.title = symbol.detail;
     if (symbol.kind === languages.SymbolKind.Array) {
       breadcrumb.classList.add('array');
     } else if (symbol.kind === languages.SymbolKind.Module) {

--- a/src/languageFeatures.ts
+++ b/src/languageFeatures.ts
@@ -341,7 +341,7 @@ function toSymbolKind(kind: ls.SymbolKind): languages.SymbolKind {
 
 function toDocumentSymbol(item: ls.DocumentSymbol): languages.DocumentSymbol {
   return {
-    detail: '',
+    detail: item.detail || '',
     range: toRange(item.range),
     name: item.name,
     kind: toSymbolKind(item.kind),


### PR DESCRIPTION
This is set to the raw value for primitives by the YAML language service.

The demo now uses this value as the title attribute on the breadcrumbs.

Closes #137