### PR TITLE
Remove support for the prefix option

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -71,14 +71,6 @@ declare module 'monaco-editor/esm/vs/editor/editor.api' {
       readonly isKubernetes?: boolean;
 
       /**
-       * If specified, this prefix will be added to all on demand schema requests
-       *
-       * @default undefined
-       * @deprecated
-       */
-      readonly prefix?: string;
-
-      /**
        * A list of known schemas and/or associations of schemas to file names.
        *
        * @default []

--- a/src/workerManager.ts
+++ b/src/workerManager.ts
@@ -48,7 +48,6 @@ export function createWorkerManager(
         createData: {
           languageSettings: defaults.diagnosticsOptions,
           enableSchemaRequest: defaults.diagnosticsOptions.enableSchemaRequest,
-          prefix: defaults.diagnosticsOptions.prefix,
           isKubernetes: defaults.diagnosticsOptions.isKubernetes,
           customTags: defaults.diagnosticsOptions.customTags,
         },

--- a/src/yamlWorker.ts
+++ b/src/yamlWorker.ts
@@ -10,10 +10,12 @@ import {
 
 import { languageId } from './constants';
 
-let defaultSchemaRequestService: (url: string) => Promise<string>;
-
-if (typeof fetch !== 'undefined') {
-  defaultSchemaRequestService = (url) => fetch(url).then((response) => response.text());
+async function schemaRequestService(uri: string): Promise<string> {
+  const response = await fetch(uri);
+  if (response.ok) {
+    return response.text();
+  }
+  throw new Error(`Schema request failed for ${uri}`);
 }
 
 export interface YAMLWorker {
@@ -36,10 +38,14 @@ export interface YAMLWorker {
 
 export function createYAMLWorker(
   ctx: worker.IWorkerContext,
-  { enableSchemaRequest, languageSettings, prefix = '' }: ICreateData,
+  { enableSchemaRequest, languageSettings }: ICreateData,
 ): YAMLWorker {
-  const service = (url: string): Promise<string> => defaultSchemaRequestService(`${prefix}${url}`);
-  const languageService = getLanguageService(enableSchemaRequest && service, null, null, null);
+  const languageService = getLanguageService(
+    enableSchemaRequest ? schemaRequestService : null,
+    null,
+    null,
+    null,
+  );
   languageService.configure(languageSettings);
 
   const getTextDocument = (uri: string): TextDocument => {
@@ -100,6 +106,5 @@ export function createYAMLWorker(
 export interface ICreateData {
   languageSettings: LanguageSettings;
   enableSchemaRequest: boolean;
-  prefix?: string;
   isKubernetes?: boolean;
 }


### PR DESCRIPTION
If it turns out people use this, we can support a custom schema request service implementation instead.

Also error responses for schema requests are now handled.