### PR TITLE
Mark vscode-uri as external dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "prettier": "2.0.5",
         "vscode-languageserver-textdocument": "^1.0.0",
         "vscode-languageserver-types": "^3.0.0",
+        "vscode-uri": "^3.0.0",
         "yaml": "2.0.0-10"
       },
       "devDependencies": {
@@ -7871,8 +7872,7 @@
     "node_modules/vscode-uri": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.0.3.tgz",
-      "integrity": "sha512-EcswR2S8bpR7fD0YPeS7r2xXExrScVMxg4MedACaWHEtx9ftCF/qHG1xGkolzTPcEmjTavCQgbVzHUIdTMzFGA==",
-      "dev": true
+      "integrity": "sha512-EcswR2S8bpR7fD0YPeS7r2xXExrScVMxg4MedACaWHEtx9ftCF/qHG1xGkolzTPcEmjTavCQgbVzHUIdTMzFGA=="
     },
     "node_modules/watchpack": {
       "version": "2.3.1",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "prettier": "2.0.5",
     "vscode-languageserver-textdocument": "^1.0.0",
     "vscode-languageserver-types": "^3.0.0",
+    "vscode-uri": "^3.0.0",
     "yaml": "2.0.0-10"
   },
   "peerDependencies": {


### PR DESCRIPTION
It doesn’t need special treatment when bundling.