### PR TITLE
Remove Monaco workspace support

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,4 @@
 import { JSONSchema4, JSONSchema6, JSONSchema7 } from 'json-schema';
-import { IEvent, languages } from 'monaco-editor/esm/vs/editor/editor.api';
 
 export interface SchemasSettings {
   /**
@@ -24,84 +23,71 @@ export interface SchemasSettings {
   uri: string;
 }
 
-declare module 'monaco-editor/esm/vs/editor/editor.api' {
-  namespace languages.yaml {
-    export interface DiagnosticsOptions {
-      /**
-       * If set, enable schema based autocompletion.
-       *
-       * @default true
-       */
-      readonly completion?: boolean;
+export interface DiagnosticsOptions {
+  /**
+   * If set, enable schema based autocompletion.
+   *
+   * @default true
+   */
+  readonly completion?: boolean;
 
-      /**
-       * A list of custom tags.
-       *
-       * @default []
-       */
-      readonly customTags?: string[];
+  /**
+   * A list of custom tags.
+   *
+   * @default []
+   */
+  readonly customTags?: string[];
 
-      /**
-       * If set, the schema service would load schema content on-demand with 'fetch' if available
-       *
-       * @default false
-       */
-      readonly enableSchemaRequest?: boolean;
+  /**
+   * If set, the schema service would load schema content on-demand with 'fetch' if available
+   *
+   * @default false
+   */
+  readonly enableSchemaRequest?: boolean;
 
-      /**
-       * If true, formatting using Prettier is enabled. Setting this to `false` does **not** exclude
-       * Prettier from the bundle.
-       *
-       * @default true
-       */
-      readonly format?: boolean;
+  /**
+   * If true, formatting using Prettier is enabled. Setting this to `false` does **not** exclude
+   * Prettier from the bundle.
+   *
+   * @default true
+   */
+  readonly format?: boolean;
 
-      /**
-       * If set, enable hover typs based the JSON schema.
-       *
-       * @default true
-       */
-      readonly hover?: boolean;
+  /**
+   * If set, enable hover typs based the JSON schema.
+   *
+   * @default true
+   */
+  readonly hover?: boolean;
 
-      /**
-       * If true, a different diffing algorithm is used to generate error messages.
-       *
-       * @default false
-       */
-      readonly isKubernetes?: boolean;
+  /**
+   * If true, a different diffing algorithm is used to generate error messages.
+   *
+   * @default false
+   */
+  readonly isKubernetes?: boolean;
 
-      /**
-       * A list of known schemas and/or associations of schemas to file names.
-       *
-       * @default []
-       */
-      readonly schemas?: SchemasSettings[];
+  /**
+   * A list of known schemas and/or associations of schemas to file names.
+   *
+   * @default []
+   */
+  readonly schemas?: SchemasSettings[];
 
-      /**
-       * If set, the validator will be enabled and perform syntax validation as well as schema
-       * based validation.
-       *
-       * @default true
-       */
-      readonly validate?: boolean;
+  /**
+   * If set, the validator will be enabled and perform syntax validation as well as schema
+   * based validation.
+   *
+   * @default true
+   */
+  readonly validate?: boolean;
 
-      /**
-       * The YAML version to use for parsing.
-       *
-       * @default '1.2'
-       */
-      readonly yamlVersion?: '1.1' | '1.2';
-    }
-
-    export interface LanguageServiceDefaults {
-      readonly onDidChange: IEvent<LanguageServiceDefaults>;
-      readonly languageId: string;
-      readonly diagnosticsOptions: DiagnosticsOptions;
-      setDiagnosticsOptions: (options: DiagnosticsOptions) => void;
-    }
-
-    export const yamlDefaults: LanguageServiceDefaults;
-  }
+  /**
+   * The YAML version to use for parsing.
+   *
+   * @default '1.2'
+   */
+  readonly yamlVersion?: '1.1' | '1.2';
 }
 
 /**
@@ -109,4 +95,4 @@ declare module 'monaco-editor/esm/vs/editor/editor.api' {
  *
  * @param options - The options to set.
  */
-export function setDiagnosticsOptions(options?: languages.yaml.DiagnosticsOptions): void;
+export function setDiagnosticsOptions(options?: DiagnosticsOptions): void;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,13 @@
 import { Emitter, languages } from 'monaco-editor/esm/vs/editor/editor.api.js';
+import { DiagnosticsOptions } from 'monaco-yaml';
 
 import { languageId } from './constants';
+import { LanguageServiceDefaults } from './types';
 import { setupMode } from './yamlMode';
 
 // --- YAML configuration and defaults ---------
 
-const diagnosticDefault: languages.yaml.DiagnosticsOptions = {
+const diagnosticDefault: DiagnosticsOptions = {
   completion: true,
   customTags: [],
   enableSchemaRequest: false,
@@ -18,18 +20,14 @@ const diagnosticDefault: languages.yaml.DiagnosticsOptions = {
 };
 
 export function createLanguageServiceDefaults(
-  initialDiagnosticsOptions: languages.yaml.DiagnosticsOptions,
-): languages.yaml.LanguageServiceDefaults {
-  const onDidChange = new Emitter<languages.yaml.LanguageServiceDefaults>();
+  initialDiagnosticsOptions: DiagnosticsOptions,
+): LanguageServiceDefaults {
+  const onDidChange = new Emitter<LanguageServiceDefaults>();
   let diagnosticsOptions = initialDiagnosticsOptions;
 
-  const languageServiceDefaults: languages.yaml.LanguageServiceDefaults = {
+  const languageServiceDefaults: LanguageServiceDefaults = {
     get onDidChange() {
       return onDidChange.event;
-    },
-
-    get languageId() {
-      return languageId;
     },
 
     get diagnosticsOptions() {
@@ -46,14 +44,6 @@ export function createLanguageServiceDefaults(
 }
 
 const yamlDefaults = createLanguageServiceDefaults(diagnosticDefault);
-
-// Export API
-function createAPI(): typeof languages.yaml {
-  return {
-    yamlDefaults,
-  };
-}
-languages.yaml = createAPI();
 
 // --- Registration to monaco editor ---
 
@@ -73,6 +63,6 @@ languages.onLanguage('yaml', () => {
  *
  * @param options - The options to set.
  */
-export function setDiagnosticsOptions(options: languages.yaml.DiagnosticsOptions = {}): void {
-  languages.yaml.yamlDefaults.setDiagnosticsOptions(options);
+export function setDiagnosticsOptions(options: DiagnosticsOptions = {}): void {
+  yamlDefaults.setDiagnosticsOptions(options);
 }

--- a/src/languageFeatures.ts
+++ b/src/languageFeatures.ts
@@ -13,6 +13,7 @@ import * as ls from 'vscode-languageserver-types';
 import { CustomFormatterOptions } from 'yaml-language-server/lib/esm/languageservice/yamlLanguageService.js';
 
 import { languageId } from './constants';
+import { LanguageServiceDefaults } from './types';
 import { YAMLWorker } from './yamlWorker';
 
 export type WorkerAccessor = (...more: Uri[]) => PromiseLike<YAMLWorker>;
@@ -60,7 +61,7 @@ function toDiagnostics(diag: ls.Diagnostic): editor.IMarkerData {
 
 export function createDiagnosticsAdapter(
   getWorker: WorkerAccessor,
-  defaults: languages.yaml.LanguageServiceDefaults,
+  defaults: LanguageServiceDefaults,
 ): void {
   const listeners = new Map<string, IDisposable>();
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,8 @@
+import { IEvent } from 'monaco-editor';
+import { DiagnosticsOptions } from 'monaco-yaml';
+
+export interface LanguageServiceDefaults {
+  readonly onDidChange: IEvent<LanguageServiceDefaults>;
+  readonly diagnosticsOptions: DiagnosticsOptions;
+  setDiagnosticsOptions: (options: DiagnosticsOptions) => void;
+}

--- a/src/workerManager.ts
+++ b/src/workerManager.ts
@@ -1,14 +1,14 @@
-import { editor, languages } from 'monaco-editor/esm/vs/editor/editor.api.js';
+import { editor } from 'monaco-editor/esm/vs/editor/editor.api.js';
 
+import { languageId } from './constants';
 import { WorkerAccessor } from './languageFeatures';
+import { LanguageServiceDefaults } from './types';
 import { YAMLWorker } from './yamlWorker';
 
 // 2min
 const STOP_WHEN_IDLE_FOR = 2 * 60 * 1000;
 
-export function createWorkerManager(
-  defaults: languages.yaml.LanguageServiceDefaults,
-): WorkerAccessor {
+export function createWorkerManager(defaults: LanguageServiceDefaults): WorkerAccessor {
   let worker: editor.MonacoWebWorker<YAMLWorker>;
   let client: Promise<YAMLWorker>;
   let lastUsedTime = 0;
@@ -42,7 +42,7 @@ export function createWorkerManager(
         // Module that exports the create() method and returns a `YAMLWorker` instance
         moduleId: 'vs/language/yaml/yamlWorker',
 
-        label: defaults.languageId,
+        label: languageId,
 
         // Passed in to the create() method
         createData: {

--- a/src/yamlMode.ts
+++ b/src/yamlMode.ts
@@ -11,6 +11,7 @@ import {
   createHoverProvider,
   createLinkProvider,
 } from './languageFeatures';
+import { LanguageServiceDefaults } from './types';
 import { createWorkerManager } from './workerManager';
 
 const richEditConfiguration: languages.LanguageConfiguration = {
@@ -45,7 +46,7 @@ const richEditConfiguration: languages.LanguageConfiguration = {
   ],
 };
 
-export function setupMode(defaults: languages.yaml.LanguageServiceDefaults): void {
+export function setupMode(defaults: LanguageServiceDefaults): void {
   const worker = createWorkerManager(defaults);
 
   languages.registerCompletionItemProvider(languageId, createCompletionItemProvider(worker));


### PR DESCRIPTION
It’s not necessary to register `monaco-yaml` in the `monaco.languages` namespace.