### PR TITLE
Bundle sourcemaps

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,8 +11,10 @@
   "typings": "./index.d.ts",
   "files": [
     "index.js",
+    "index.js.map",
     "index.d.ts",
-    "yaml.worker.js"
+    "yaml.worker.js",
+    "yaml.worker.js.map"
   ],
   "workspaces": [
     "examples/*"


### PR DESCRIPTION
index.js and yaml.worker.js both have references to their sourcemaps in comments at the end of the files, but because the sourcemaps aren't included in the package, this results in noisy Webpack warnings like

```
WARNING in ./node_modules/monaco-yaml/index.js
Module Warning (from ./node_modules/source-map-loader/dist/cjs.js):
Failed to parse source map from './node_modules/monaco-yaml/index.js.map' file: Error: ENOENT: no such file or directory, open './node_modules/monaco-yaml/index.js.map'
```

I think it's useful to have the sourcemaps, so rather than turning them off, this PR includes them in the package. 