### PR TITLE
Add option to hide schema URI in tooltips

### DIFF
--- a/examples/demo/src/index.ts
+++ b/examples/demo/src/index.ts
@@ -13,7 +13,7 @@ import {
   Uri,
 } from 'monaco-editor/esm/vs/editor/editor.api.js';
 import { StandaloneServices } from 'monaco-editor/esm/vs/editor/standalone/browser/standaloneServices.js';
-import { Hooks, SchemasSettings, setDiagnosticsOptions } from 'monaco-yaml';
+import { SchemasSettings, setDiagnosticsOptions } from 'monaco-yaml';
 
 // NOTE: This will give you all editor featues. If you would prefer to limit to only the editor
 // features you want to use, import them each individually. See this example: (https://github.com/microsoft/monaco-editor-samples/blob/main/browser-esm-webpack-small/index.js#L1-L91)
@@ -40,24 +40,13 @@ window.MonacoEnvironment = {
   },
 };
 
-const hooks: Hooks = {
-  onHoverInfo(c) {
-    console.log('onHoverInfo', c);
-    return c;
-  },
-  overDiagnostic(c) {
-    console.log('overDiagnostic', c);
-    return c;
-  },
-};
-
 const defaultSchema: SchemasSettings = {
   uri: defaultSchemaUri,
   fileMatch: ['monaco-yaml.yaml'],
 };
 
 setDiagnosticsOptions({
-  hooks,
+  showSchemaUrls: false,
   schemas: [defaultSchema],
 });
 
@@ -163,7 +152,7 @@ fetch('https://www.schemastore.org/api/json/catalog.json').then(async (response)
   }
 
   setDiagnosticsOptions({
-    hooks,
+    showSchemaUrls: false,
     validate: true,
     enableSchemaRequest: true,
     format: true,

--- a/examples/demo/src/index.ts
+++ b/examples/demo/src/index.ts
@@ -13,7 +13,7 @@ import {
   Uri,
 } from 'monaco-editor/esm/vs/editor/editor.api.js';
 import { StandaloneServices } from 'monaco-editor/esm/vs/editor/standalone/browser/standaloneServices.js';
-import { SchemasSettings, setDiagnosticsOptions } from 'monaco-yaml';
+import { Hooks, SchemasSettings, setDiagnosticsOptions } from 'monaco-yaml';
 
 // NOTE: This will give you all editor featues. If you would prefer to limit to only the editor
 // features you want to use, import them each individually. See this example: (https://github.com/microsoft/monaco-editor-samples/blob/main/browser-esm-webpack-small/index.js#L1-L91)
@@ -40,12 +40,24 @@ window.MonacoEnvironment = {
   },
 };
 
+const hooks: Hooks = {
+  onHoverInfo(c) {
+    console.log('onHoverInfo', c);
+    return c;
+  },
+  overDiagnostic(c) {
+    console.log('overDiagnostic', c);
+    return c;
+  },
+};
+
 const defaultSchema: SchemasSettings = {
   uri: defaultSchemaUri,
   fileMatch: ['monaco-yaml.yaml'],
 };
 
 setDiagnosticsOptions({
+  hooks,
   schemas: [defaultSchema],
 });
 
@@ -151,6 +163,7 @@ fetch('https://www.schemastore.org/api/json/catalog.json').then(async (response)
   }
 
   setDiagnosticsOptions({
+    hooks,
     validate: true,
     enableSchemaRequest: true,
     format: true,

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,11 @@
 import { JSONSchema4, JSONSchema6, JSONSchema7 } from 'json-schema';
 import { IEvent } from 'monaco-editor';
 
+export interface Hooks {
+  readonly overDiagnostic?: (diag: ls.Diagnostic) => ls.Diagnostic;
+  readonly onHoverInfo?: (hover: ls.Hover) => ls.Hover;
+}
+
 export interface SchemasSettings {
   /**
    * A `Uri` file match which will trigger the schema validation. This may be a glob or an exact
@@ -25,6 +30,7 @@ export interface SchemasSettings {
 }
 
 export interface DiagnosticsOptions {
+  readonly hooks?: Hooks;
   /**
    * If set, enable schema based autocompletion.
    *

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,11 +1,6 @@
 import { JSONSchema4, JSONSchema6, JSONSchema7 } from 'json-schema';
 import { IEvent } from 'monaco-editor';
 
-export interface Hooks {
-  readonly overDiagnostic?: (diag: ls.Diagnostic) => ls.Diagnostic;
-  readonly onHoverInfo?: (hover: ls.Hover) => ls.Hover;
-}
-
 export interface SchemasSettings {
   /**
    * A `Uri` file match which will trigger the schema validation. This may be a glob or an exact
@@ -30,7 +25,12 @@ export interface SchemasSettings {
 }
 
 export interface DiagnosticsOptions {
-  readonly hooks?: Hooks;
+  /**
+   * If set, will show schema urls on hover.
+   *
+   * @default true
+   */
+  readonly showSchemaUrls?: boolean;
   /**
    * If set, enable schema based autocompletion.
    *

--- a/src/yamlMode.ts
+++ b/src/yamlMode.ts
@@ -13,6 +13,7 @@ import {
   createHoverProvider,
   createLinkProvider,
   createMarkerDataProvider,
+  mkHooks,
 } from './languageFeatures';
 import { CreateData, YAMLWorker } from './yaml.worker';
 
@@ -65,11 +66,11 @@ export function setupMode(defaults: LanguageServiceDefaults): void {
     });
   });
 
+  const hooks = mkHooks(defaults.diagnosticsOptions.showSchemaUrls);
   monaco.languages.registerCompletionItemProvider(
     languageId,
     createCompletionItemProvider(worker.getWorker),
   );
-  const hooks = defaults.diagnosticsOptions.hooks ?? {};
   let hoverProvider = monaco.languages.registerHoverProvider(
     languageId,
     createHoverProvider(hooks, worker.getWorker),
@@ -99,13 +100,12 @@ export function setupMode(defaults: LanguageServiceDefaults): void {
     createMarkerDataProvider(hooks, worker.getWorker),
   );
   defaults.onDidChange(() => {
-    const hooks = defaults.diagnosticsOptions.hooks ?? {};
+    const hooks = mkHooks(defaults.diagnosticsOptions.showSchemaUrls);
     hoverProvider.dispose();
     hoverProvider = monaco.languages.registerHoverProvider(
       languageId,
       createHoverProvider(hooks, worker.getWorker),
     );
-
     codeActionProvider.dispose();
     codeActionProvider = monaco.languages.registerCodeActionProvider(
       languageId,


### PR DESCRIPTION
Fixes https://github.com/remcohaszing/monaco-yaml/issues/177

<img width="519" alt="Screen Shot 2022-06-25 at 15 52 06" src="https://user-images.githubusercontent.com/1932383/175772387-5fbbea0c-3179-4cd8-9cb2-38073be1c308.png">


First I tried to more general implementation, but looks like it's not possible for DiagnosticsOptions to contain functions, so in the last commit instead added just one flag.

(i've left my first attempt in commits with expectation that the PR will be squash merged, if not happy to clean up commits if this is good to go)