### PR TITLE
Fix: Updated YAML package vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "vscode-languageserver-textdocument": "^1.0.0",
         "vscode-languageserver-types": "^3.0.0",
         "vscode-uri": "^3.0.0",
-        "yaml": "^2.0.0"
+        "yaml": "^2.0.2"
       },
       "devDependencies": {
         "@playwright/test": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "vscode-languageserver-textdocument": "^1.0.0",
     "vscode-languageserver-types": "^3.0.0",
     "vscode-uri": "^3.0.0",
-    "yaml": "^2.0.0"
+    "yaml": "^2.0.2"
   },
   "peerDependencies": {
     "monaco-editor": ">=0.36"


### PR DESCRIPTION
A vulnerability was found within the `yaml` repo, where an uncaught exception was found within the yaml repo prior to 2.2.2. Further details of this can be found here: https://github.com/advisories/GHSA-f9xv-q969-pqx4

This PR attempts to address this vulnerability. All current tests were run, and passed as expected.