### PR TITLE
fix: autompletion not working in examples

### DIFF
--- a/examples/demo/src/index.ts
+++ b/examples/demo/src/index.ts
@@ -106,7 +106,12 @@ formatting:       Formatting is supported too! Under the hood this is powered by
 const ed = editor.create(document.getElementById('editor')!, {
   automaticLayout: true,
   model: editor.createModel(value, 'yaml', Uri.parse('monaco-yaml.yaml')),
-  theme: window.matchMedia('(prefers-color-scheme: dark)').matches ? 'vs-dark' : 'vs-light'
+  theme: window.matchMedia('(prefers-color-scheme: dark)').matches ? 'vs-dark' : 'vs-light',
+  quickSuggestions: {
+    other: true,
+    comments: false,
+    strings: true
+  }
 })
 
 const select = document.getElementById('schema-selection') as HTMLSelectElement

--- a/examples/monaco-editor-webpack-plugin/src/index.js
+++ b/examples/monaco-editor-webpack-plugin/src/index.js
@@ -50,7 +50,12 @@ monaco.editor.createModel(
 
 const editor = monaco.editor.create(document.getElementById('editor'), {
   automaticLayout: true,
-  model: prettierc
+  model: prettierc,
+  quickSuggestions: {
+    other: true,
+    comments: false,
+    strings: true
+  }
 })
 
 const select = document.getElementById('model')

--- a/examples/vite-example/index.js
+++ b/examples/vite-example/index.js
@@ -65,7 +65,12 @@ monaco.editor.createModel(
 
 const editor = monaco.editor.create(document.getElementById('editor'), {
   automaticLayout: true,
-  model: prettierc
+  model: prettierc,
+  quickSuggestions: {
+    other: true,
+    comments: false,
+    strings: true
+  }
 })
 
 const select = document.getElementById('model')


### PR DESCRIPTION
fix #223

The language lexer in `monaco-editor` treats yaml's word as a string type.
https://github.com/microsoft/monaco-editor/blob/main/src/basic-languages/yaml/yaml.ts#L99

And the `monaco-editor` does not enable quick suggestions for string type by default.
https://github.com/microsoft/vscode/blob/main/src/vs/editor/contrib/suggest/browser/suggestInlineCompletions.ts#L134

So we should set `quickSuggestions.strings` to true to enable autocompletion, similar to what `vscode-yaml` does.
https://github.com/redhat-developer/vscode-yaml/blob/main/package.json#L233