### PR TITLE
Make options optional again

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -131,7 +131,7 @@ export interface MonacoYaml extends IDisposable {
  * @returns
  *   A disposable object that can be used to update `monaco-yaml`
  */
-export function configureMonacoYaml(monaco: MonacoEditor, options: MonacoYamlOptions): MonacoYaml {
+export function configureMonacoYaml(monaco: MonacoEditor, options?: MonacoYamlOptions): MonacoYaml {
   const createData: MonacoYamlOptions = {
     completion: true,
     customTags: [],


### PR DESCRIPTION
In version 5.1.1 passing options to `configureMonacoYaml` was optional and that's also what the README says at https://github.com/remcohaszing/monaco-yaml?tab=readme-ov-file#configuremonacoyamlmonaco-options

Updating to 5.2.0 resulted in typescript errors as options are now required.

This PR reverts that change.