### PR TITLE
fix: missing client capabilities and markdown descriptions

### DIFF
--- a/src/yaml.worker.ts
+++ b/src/yaml.worker.ts
@@ -11,6 +11,7 @@ import {
   type FormattingOptions,
   type Hover,
   type LocationLink,
+  MarkupKind,
   type Position,
   type Range,
   type SelectionRange,
@@ -134,7 +135,20 @@ initialize<YAMLWorker, MonacoYamlOptions>((ctx, { enableSchemaRequest, ...langua
     // @ts-expect-error Type definitions are wrong. This may be null.
     schemaRequestService: enableSchemaRequest ? schemaRequestService : null,
     telemetry,
-    workspaceContext
+    workspaceContext,
+    // Copied from https://github.com/microsoft/vscode-json-languageservice/blob/493010da9dc2cd1cc139d403d4709d97064b17e9/src/jsonLanguageTypes.ts#L325-L335
+    // Usage: https://github.com/microsoft/monaco-editor/blob/f6dc0eb8fce67e57f6036f4769d92c1666cdf546/src/language/json/jsonWorker.ts#L38
+    clientCapabilities: {
+      textDocument: {
+        completion: {
+          completionItem: {
+            documentationFormat: [MarkupKind.Markdown, MarkupKind.PlainText],
+            commitCharactersSupport: true
+          }
+        },
+        moniker: {}
+      }
+    }
   })
 
   const withDocument =


### PR DESCRIPTION
It seems monaco-yaml does not set `clientCapabilities` while calling `getLanguageService`, which is exported by yaml-language-server. This causes the [`doesSupportMarkdown`](https://github.com/redhat-developer/yaml-language-server/blob/f039273ee5b6974db5ad34b03bb24cfe09b64447/src/languageservice/services/yamlCompletion.ts#L1642-L1652) in yaml-language-server always return `undefined` and makes the `markdownDescription` not being correctly rendered in the completion item.

However, I can see `clientCapabilities` [is being set](https://github.com/redhat-developer/yaml-language-server/blob/f039273ee5b6974db5ad34b03bb24cfe09b64447/test/utils/testHelper.ts#L87) by the test helper in yaml-language-server with a constant imported from vscode-json-languageservice.

Similiar usage in `jsonWorker` in `monaco-editor` can be found here: https://github.com/microsoft/monaco-editor/blob/f6dc0eb8fce67e57f6036f4769d92c1666cdf546/src/language/json/jsonWorker.ts#L38

This pull request copied the `clientCapabilities` constant from vscode-json-languageservice to avoid introducing new dependencies.