### PR TITLE
fix: missing client markdown capabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "remark-cli": "^11.0.0",
         "remark-preset-remcohaszing": "^1.0.0",
         "typescript": "^5.0.0",
+        "vscode-json-languageservice": "^5.4.1",
         "yaml-language-server": "^1.0.0"
       },
       "funding": {
@@ -1820,6 +1821,13 @@
       "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/@vscode/l10n": {
+      "version": "0.0.18",
+      "resolved": "https://registry.npmjs.org/@vscode/l10n/-/l10n-0.0.18.tgz",
+      "integrity": "sha512-KYSIHVmslkaCDyw013pphY+d7x1qV8IZupYfeIfzNA+nsaWHbn5uPuQRvdRFsa9zFzGeudPuoGoZ1Op4jrJXIQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@webassemblyjs/ast": {
       "version": "1.12.1",
@@ -12963,20 +12971,17 @@
       }
     },
     "node_modules/vscode-json-languageservice": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/vscode-json-languageservice/-/vscode-json-languageservice-4.1.8.tgz",
-      "integrity": "sha512-0vSpg6Xd9hfV+eZAaYN63xVVMOTmJ4GgHxXnkLCh+9RsQBkWKIghzLhW2B9ebfG+LQQg8uLtsQ2aUKjTgE+QOg==",
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/vscode-json-languageservice/-/vscode-json-languageservice-5.4.1.tgz",
+      "integrity": "sha512-5czFGNyVPxz3ZJYl8R3a3SuIj5gjhmGF4Wv05MRPvD4DEnHK6b8km4VbNMJNHBlTCh7A0aHzUbPVzo+0C18mCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "jsonc-parser": "^3.0.0",
-        "vscode-languageserver-textdocument": "^1.0.1",
-        "vscode-languageserver-types": "^3.16.0",
-        "vscode-nls": "^5.0.0",
-        "vscode-uri": "^3.0.2"
-      },
-      "engines": {
-        "npm": ">=7.0.0"
+        "@vscode/l10n": "^0.0.18",
+        "jsonc-parser": "^3.3.1",
+        "vscode-languageserver-textdocument": "^1.0.12",
+        "vscode-languageserver-types": "^3.17.5",
+        "vscode-uri": "^3.0.8"
       }
     },
     "node_modules/vscode-jsonrpc": {
@@ -13012,9 +13017,9 @@
       }
     },
     "node_modules/vscode-languageserver-textdocument": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.11.tgz",
-      "integrity": "sha512-X+8T3GoiwTVlJbicx/sIAF+yuJAqz8VvwJyoMVhwEMoEKE/fkDmrqUgDMyBECcM2A2frVZIUj5HI/ErRXCfOeA==",
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz",
+      "integrity": "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==",
       "license": "MIT"
     },
     "node_modules/vscode-languageserver-types": {
@@ -13676,6 +13681,23 @@
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/yaml-language-server/node_modules/vscode-json-languageservice": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/vscode-json-languageservice/-/vscode-json-languageservice-4.1.8.tgz",
+      "integrity": "sha512-0vSpg6Xd9hfV+eZAaYN63xVVMOTmJ4GgHxXnkLCh+9RsQBkWKIghzLhW2B9ebfG+LQQg8uLtsQ2aUKjTgE+QOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jsonc-parser": "^3.0.0",
+        "vscode-languageserver-textdocument": "^1.0.1",
+        "vscode-languageserver-types": "^3.16.0",
+        "vscode-nls": "^5.0.0",
+        "vscode-uri": "^3.0.2"
+      },
+      "engines": {
+        "npm": ">=7.0.0"
       }
     },
     "node_modules/yaml-language-server/node_modules/yaml": {

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "remark-cli": "^11.0.0",
     "remark-preset-remcohaszing": "^1.0.0",
     "typescript": "^5.0.0",
+    "vscode-json-languageservice": "^5.4.1",
     "yaml-language-server": "^1.0.0"
   }
 }

--- a/src/yaml.worker.ts
+++ b/src/yaml.worker.ts
@@ -1,4 +1,5 @@
 import { initialize } from 'monaco-worker-manager/worker'
+import { ClientCapabilities } from 'vscode-json-languageservice/lib/esm/jsonLanguageTypes.js'
 import { TextDocument } from 'vscode-languageserver-textdocument'
 import {
   type CodeAction,
@@ -134,7 +135,11 @@ initialize<YAMLWorker, MonacoYamlOptions>((ctx, { enableSchemaRequest, ...langua
     // @ts-expect-error Type definitions are wrong. This may be null.
     schemaRequestService: enableSchemaRequest ? schemaRequestService : null,
     telemetry,
-    workspaceContext
+    workspaceContext,
+    // https://github.com/microsoft/vscode-json-languageservice/blob/493010da9dc2cd1cc139d403d4709d97064b17e9/src/jsonLanguageTypes.ts#L325-L335
+    // Usage: https://github.com/microsoft/monaco-editor/blob/f6dc0eb8fce67e57f6036f4769d92c1666cdf546/src/language/json/jsonWorker.ts#L38
+    // @ts-expect-error `moniker` is missing from `ClientCapabilities.LATEST`
+    clientCapabilities: ClientCapabilities.LATEST
   })
 
   const withDocument =


### PR DESCRIPTION
**tl;dr** This pull request adds the missing `clientCapabilities` in the YAML worker to fix the broken support for `markdownDescription`.

It seems monaco-yaml does not set `clientCapabilities` upon calling `getLanguageService`, which is exported by yaml-language-server. This causes the [`doesSupportMarkdown`](https://github.com/redhat-developer/yaml-language-server/blob/f039273ee5b6974db5ad34b03bb24cfe09b64447/src/languageservice/services/yamlCompletion.ts#L1642-L1652) in yaml-language-server always return undefined and makes the `markdownDescription` not being correctly rendered in the completion item.

I can see `clientCapabilities` [is being set](https://github.com/redhat-developer/yaml-language-server/blob/f039273ee5b6974db5ad34b03bb24cfe09b64447/test/utils/testHelper.ts#L87) by the test helper in yaml-language-server with a constant imported from vscode-json-languageservice.

Similiar usage in jsonWorker in monaco-editor can be found here: https://github.com/microsoft/monaco-editor/blob/f6dc0eb8fce67e57f6036f4769d92c1666cdf546/src/language/json/jsonWorker.ts#L38

_This pull request replaces #248_ 