### PR TITLE
Use latest version of monaco-marker-data-provider

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
       "dependencies": {
         "jsonc-parser": "^3.0.0",
         "monaco-languageserver-types": "^0.4.0",
-        "monaco-marker-data-provider": "^1.0.0",
+        "monaco-marker-data-provider": "^1.2.4",
         "monaco-types": "^0.1.0",
         "monaco-worker-manager": "^2.0.0",
         "path-browserify": "^1.0.0",
@@ -8113,10 +8113,9 @@
       }
     },
     "node_modules/monaco-marker-data-provider": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/monaco-marker-data-provider/-/monaco-marker-data-provider-1.2.3.tgz",
-      "integrity": "sha512-BOiQs9UNEwVrF1rwYI32HUP8D7JTuHlJRlykx83e4+jfh1ceBWIBfB5ENDVSFUz651d95kxjKj36vV2JO3zr9w==",
-      "license": "MIT",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/monaco-marker-data-provider/-/monaco-marker-data-provider-1.2.4.tgz",
+      "integrity": "sha512-4DsPgsAqpTyUDs3humXRBPUJoihTv+L6v9aupQWD80X2YXaCXUd11mWYeSCYHuPgdUmjFaNWCEOjQ6ewf/QA1Q==",
       "dependencies": {
         "monaco-types": "^0.1.0"
       },

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "dependencies": {
     "jsonc-parser": "^3.0.0",
     "monaco-languageserver-types": "^0.4.0",
-    "monaco-marker-data-provider": "^1.0.0",
+    "monaco-marker-data-provider": "^1.2.4",
     "monaco-types": "^0.1.0",
     "monaco-worker-manager": "^2.0.0",
     "path-browserify": "^1.0.0",


### PR DESCRIPTION
Should fix #259 - looks like it wasn't pulling in a new enough version of `monaco-marker-data-provider` for whatever reason.