### PR TITLE
Update monaco-marker-data-provider to 1.2.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
       "dependencies": {
         "jsonc-parser": "^3.0.0",
         "monaco-languageserver-types": "^0.4.0",
-        "monaco-marker-data-provider": "^1.0.0",
+        "monaco-marker-data-provider": "^1.2.4",
         "monaco-types": "^0.1.0",
         "monaco-worker-manager": "^2.0.0",
         "path-browserify": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "dependencies": {
     "jsonc-parser": "^3.0.0",
     "monaco-languageserver-types": "^0.4.0",
-    "monaco-marker-data-provider": "^1.0.0",
+    "monaco-marker-data-provider": "^1.2.4",
     "monaco-types": "^0.1.0",
     "monaco-worker-manager": "^2.0.0",
     "path-browserify": "^1.0.0",


### PR DESCRIPTION
I have `Model is disposed!` error on every React rerender. This problem was fixed in the last monaco-marker-data-provider release v1.2.4: https://github.com/remcohaszing/monaco-marker-data-provider/releases/tag/v1.2.4. Now I fix it with "overrides" package.json section. It will be great to remove this section after pr merge.