### PR TITLE
fix(build): use path-browserify-esm for node:path replacement

### DIFF
--- a/build.js
+++ b/build.js
@@ -38,10 +38,9 @@ await build({
         onResolve({ filter: /^lodash$/ }, () => ({
           path: join(import.meta.dirname, 'fillers/lodash.ts')
         }))
-        // The yaml language service uses path. We can stub it using path-browserify.
+        // The yaml language service uses path. We can stub it using path-browserify-esm.
         onResolve({ filter: /^path$/ }, () => ({
-          path: 'path-browserify',
-          external: true,
+          path: join(import.meta.dirname, 'fillers/path.ts'),
           sideEffects: false
         }))
         // This tiny filler implementation serves all our needs.

--- a/examples/vite-example/vite.config.ts
+++ b/examples/vite-example/vite.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite'
+
+// https://vite.dev/config/
+export default defineConfig({
+  optimizeDeps: {
+    exclude: ['path-browserify']
+  }
+})
+

--- a/fillers/path.ts
+++ b/fillers/path.ts
@@ -1,0 +1,3 @@
+import path from 'path-browserify-esm'
+
+export const { basename, join, normalize, sep } = path

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "monaco-marker-data-provider": "^1.0.0",
         "monaco-types": "^0.1.0",
         "monaco-worker-manager": "^2.0.0",
-        "path-browserify": "^1.0.0",
+        "path-browserify-esm": "^1.0.6",
         "prettier": "^3.0.0",
         "vscode-languageserver-textdocument": "^1.0.0",
         "vscode-languageserver-types": "^3.0.0",
@@ -8831,10 +8831,10 @@
         "tslib": "^2.0.3"
       }
     },
-    "node_modules/path-browserify": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
-      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
+    "node_modules/path-browserify-esm": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/path-browserify-esm/-/path-browserify-esm-1.0.6.tgz",
+      "integrity": "sha512-9nUwYvvu/yq1PYrUyYCihNWmpzacaRYF6gGbjLWErrZ4MRDWyfPN7RpE8E7tsw8eqBU/rr7mcoTXbS+Vih8uUA==",
       "license": "MIT"
     },
     "node_modules/path-exists": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "monaco-marker-data-provider": "^1.0.0",
     "monaco-types": "^0.1.0",
     "monaco-worker-manager": "^2.0.0",
-    "path-browserify": "^1.0.0",
+    "path-browserify-esm": "^1.0.6",
     "prettier": "^3.0.0",
     "vscode-languageserver-textdocument": "^1.0.0",
     "vscode-languageserver-types": "^3.0.0",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
     include: [
       'jsonc-parser',
       'monaco-worker-manager/worker',
-      'path-browserify',
+      'path-browserify-esm',
       'prettier/plugins/yaml',
       'prettier/standalone',
       'vscode-languageserver-textdocument',


### PR DESCRIPTION
Hey there! Firstly, thanks for the handy package, it's been extremely useful!

As others have noticed (https://github.com/remcohaszing/monaco-yaml/issues/270), we are also experiencing an issue when running our projects locally (i.e. in "dev mode") with `monaco-yaml` that produces the errors detailed in #270.

In our case, the issue is related to `vite`, which is a fairly common option nowadays, but it might also occur with other tooling.

Tooling aside, I *think* the resulting `yaml.worker.js` is technically problematic in a browser because the ESM `yaml.worker.js` file imports `path-browserify`, and `path-browserify` is CJS, which isn't natively supported in browsers.

I'm guessing `vite`'s optimize heuristics (https://vite.dev/guide/dep-pre-bundling) don't quite reach `path-browserify` because it's imported by an ESM file (not totally sure, but I started going down a rabbit hole to find out :sweat_smile:).

For anyone hitting this issue while using `vite`, a quick fix is to add this to the `vite` config:

```js
...
    optimizeDeps: {
      include: ['path-browserify'],
    },
...
```

This manually tells `vite` to "optimize" `path-browserify` and convert the CJS specifics into something that can run in a browser.

A better fix (with unfortunate caveats, see below) would be to use an ESM-compatible `path` dependency such as `path-browserify-esm`, especially considering the upstream project `yaml-language-server` (https://github.com/redhat-developer/yaml-language-server) is an ESM project using ESM imports.

---

This PR switches the build to inject `path-browserify-esm` instead, which produces no errors when running locally.

I've also added some vite config to the `vite-example` to mirror what we and other folks are probably seeing. I would guess you aren't seeing this by default in the `vite-example` because the dependency is using a `file://` reference in its package file to avoid the circular dependency.

Now for the caveat: I noticed that whilst `path-browserify-esm` has around 40,000 weekly downloads according to npm and is currently on version `1.0.6` in the registry, when looking at the GitHub repo (https://github.com/Hocti/path-browserify-esm), the package file says `1.0.5`, plus the Issues tab on the repo seems to have been turned off by the user.

I took a look at the differences, and it's a harmless TS fix, but I still couldn't find this amend or release anywhere in the repo.

Therefore, whether you want to trust this package is another thing and totally up to you. I had a brief look at other ESM path implementations but couldn't immediately find any better alternative.

A final option would be to just add the necessary path functions to `fillers/path.ts` and skip a dependency completely. I would guess this would be fairly risk-free.

All in all, I thought I'd submit the PR, detail what I found, and leave it up to you. At the very least, the above `optimizeDeps` config would help folks hitting this issue while using `vite`.

If you'd prefer to omit the `path-*` dependency and copy in the code from elsewhere, also let me know, I'd be happy to submit an alternative PR for that as well.

Otherwise feel free to close this PR if you want to leave things as they are 👍 