### PR TITLE
Add getOptions method to retrieve current configuration of monaco-yaml

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -187,6 +187,11 @@ export interface MonacoYaml extends IDisposable {
    * Recondigure `monaco-yaml`.
    */
   update: (options: MonacoYamlOptions) => Promise<undefined>
+
+  /**
+   * Get the current configuration of `monaco-yaml`.
+   */
+  getOptions: () => MonacoYamlOptions
 }
 
 /**
@@ -425,6 +430,10 @@ export function configureMonacoYaml(monaco: MonacoEditor, options?: MonacoYamlOp
     async update(newOptions) {
       workerManager.updateCreateData(Object.assign(createData, newOptions))
       await markerDataProvider.revalidate()
+    },
+
+    getOptions() {
+      return createData
     }
   }
 }


### PR DESCRIPTION
## Add `getOptions()` method to retrieve current configuration

**Fixes #253**

### Summary

Adds a `getOptions()` method to the `MonacoYaml` interface that returns the current `MonacoYamlOptions` configuration.

### Motivation

In v4, users could access the current configuration via `yamlDefaults.diagnosticsOptions`. After migrating to v5, there was no way to retrieve the current options before updating them, making it difficult to perform incremental updates (e.g., adding schemas to existing configuration).

### Changes

- Added `getOptions: () => MonacoYamlOptions` to the `MonacoYaml` interface
- Implemented the method to return the current `createData` configuration object

### Usage Example

```typescript
const monacoYaml = configureMonacoYaml(monaco, { schemas: [...] })

// Get current options
const currentOptions = monacoYaml.getOptions()

// Add new schemas while preserving existing ones
await monacoYaml.update({
  ...currentOptions,
  schemas: [...currentOptions.schemas, newSchema]
})
```