### PR TITLE
feat: add worker factory option for Monaco Editor >= 0.55

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ offers to configure the YAML language support.
 - [API](#api)
   - [`configureMonacoYaml(monaco, options?)`](#configuremonacoyamlmonaco-options)
 - [FAQ](#faq)
+  - [Using with Monaco Editor >= 0.55](#using-with-monaco-editor--055)
   - [Does this work with the Monaco UMD bundle?](#does-this-work-with-the-monaco-umd-bundle)
   - [Does this work with Monaco Editor from a CDN?](#does-this-work-with-monaco-editor-from-a-cdn)
   - [Does this work with `@monaco-editor/loader` or `@monaco-editor/react`?](#does-this-work-with-monaco-editorloader-or-monaco-editorreact)
@@ -191,6 +192,9 @@ Configure `monaco-yaml`.
 - `schemas` (`object[]`): A list of known schemas and/or associations of schemas to file names.
   (Default: `[]`)
 - `validate` (`boolean`): based validation. (Default: `true`)
+- `worker` (`() => Worker`): A factory function that creates a new `Worker` for the YAML language
+  service. Required for Monaco Editor >= 0.55. See
+  [Using with Monaco Editor >= 0.55](#using-with-monaco-editor--055).
 - `yamlVersion` (`'1.1' | '1.2'`): The YAML version to use for parsing. (Default: `1,2`)
 
 #### Returns
@@ -198,6 +202,66 @@ Configure `monaco-yaml`.
 An object that can be used to dispose or update `monaco-yaml`.
 
 ## FAQ
+
+### Using with Monaco Editor >= 0.55
+
+Monaco Editor **0.55** introduced a breaking change to the `createWebWorker` API: the `Worker`
+instance must now be provided directly by the caller. Previous versions created the worker internally
+via `MonacoEnvironment.getWorker` / `MonacoEnvironment.getWorkerUrl`.
+
+To support Monaco Editor >= 0.55, pass the `worker` option — a factory function that creates a new
+`Worker` — to `configureMonacoYaml`. You no longer need to set up `MonacoEnvironment.getWorker` for
+the `yaml` label.
+
+**Using Vite:**
+
+Create a local worker wrapper (required because Vite's dependency pre-bundling can break the worker
+protocol):
+
+```js
+// yaml.worker.js
+import 'monaco-yaml/yaml.worker.js'
+```
+
+Then pass the worker factory:
+
+```typescript
+import * as monaco from 'monaco-editor'
+import { configureMonacoYaml } from 'monaco-yaml'
+import YamlWorker from './yaml.worker?worker'
+
+configureMonacoYaml(monaco, {
+  worker: () => new YamlWorker(),
+  enableSchemaRequest: true,
+  schemas: [
+    {
+      fileMatch: ['**/.prettierrc.*'],
+      uri: 'https://json.schemastore.org/prettierrc.json'
+    }
+  ]
+})
+```
+
+**Using Webpack 5:**
+
+```typescript
+import * as monaco from 'monaco-editor'
+import { configureMonacoYaml } from 'monaco-yaml'
+
+configureMonacoYaml(monaco, {
+  worker: () => new Worker(new URL('monaco-yaml/yaml.worker', import.meta.url)),
+  enableSchemaRequest: true,
+  schemas: [
+    {
+      fileMatch: ['**/.prettierrc.*'],
+      uri: 'https://json.schemastore.org/prettierrc.json'
+    }
+  ]
+})
+```
+
+For Monaco Editor < 0.55, omit the `worker` option and configure `MonacoEnvironment.getWorker` as
+described in the [Usage](#usage) section above.
 
 ### Does this work with the Monaco UMD bundle?
 

--- a/examples/demo/package.json
+++ b/examples/demo/package.json
@@ -14,7 +14,7 @@
     "css-minimizer-webpack-plugin": "^7.0.0",
     "html-webpack-plugin": "^5.0.0",
     "mini-css-extract-plugin": "^2.0.0",
-    "monaco-editor": "^0.52.0",
+    "monaco-editor": "0.55.1",
     "monaco-yaml": "file:../..",
     "ts-loader": "^9.0.0",
     "webpack": "^5.0.0",

--- a/examples/demo/src/index.ts
+++ b/examples/demo/src/index.ts
@@ -18,8 +18,6 @@ window.MonacoEnvironment = {
     switch (label) {
       case 'editorWorkerService':
         return new Worker(new URL('monaco-editor/esm/vs/editor/editor.worker', import.meta.url))
-      case 'yaml':
-        return new Worker(new URL('monaco-yaml/yaml.worker', import.meta.url))
       default:
         throw new Error(`Unknown label ${label}`)
     }
@@ -34,6 +32,7 @@ const defaultSchema: SchemasSettings = {
 
 const monacoYaml = configureMonacoYaml(monaco, {
   enableSchemaRequest: true,
+  worker: () => new Worker(new URL('monaco-yaml/yaml.worker', import.meta.url)),
   schemas: [defaultSchema]
 })
 

--- a/examples/monaco-editor-webpack-plugin/package.json
+++ b/examples/monaco-editor-webpack-plugin/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "css-loader": "^7.0.0",
     "html-webpack-plugin": "^5.0.0",
-    "monaco-editor": "^0.52.0",
+    "monaco-editor": "0.55.1",
     "monaco-editor-webpack-plugin": "^7.0.0",
     "monaco-yaml": "file:../..",
     "style-loader": "^4.0.0",

--- a/examples/monaco-editor-webpack-plugin/src/index.js
+++ b/examples/monaco-editor-webpack-plugin/src/index.js
@@ -3,6 +3,7 @@ import { configureMonacoYaml } from 'monaco-yaml'
 
 configureMonacoYaml(monaco, {
   enableSchemaRequest: true,
+  worker: () => new Worker(new URL('monaco-yaml/yaml.worker', import.meta.url)),
   schemas: [
     {
       // If YAML file is opened matching this glob

--- a/examples/vite-example/index.js
+++ b/examples/vite-example/index.js
@@ -8,8 +8,6 @@ window.MonacoEnvironment = {
     switch (label) {
       case 'editorWorkerService':
         return new EditorWorker()
-      case 'yaml':
-        return new YamlWorker()
       default:
         throw new Error(`Unknown label ${label}`)
     }
@@ -18,6 +16,7 @@ window.MonacoEnvironment = {
 
 configureMonacoYaml(monaco, {
   enableSchemaRequest: true,
+  worker: () => new YamlWorker(),
   schemas: [
     {
       // If YAML file is opened matching this glob

--- a/examples/vite-example/package.json
+++ b/examples/vite-example/package.json
@@ -8,7 +8,7 @@
     "build": "vite build"
   },
   "dependencies": {
-    "monaco-editor": "^0.52.0",
+    "monaco-editor": "0.55.1",
     "monaco-yaml": "file:../..",
     "vite": "^7.0.0"
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,7 +53,7 @@
         "css-minimizer-webpack-plugin": "^7.0.0",
         "html-webpack-plugin": "^5.0.0",
         "mini-css-extract-plugin": "^2.0.0",
-        "monaco-editor": "^0.52.0",
+        "monaco-editor": "0.55.1",
         "monaco-yaml": "file:../..",
         "ts-loader": "^9.0.0",
         "webpack": "^5.0.0",
@@ -61,19 +61,13 @@
         "webpack-dev-server": "^5.0.0"
       }
     },
-    "examples/demo/node_modules/monaco-editor": {
-      "version": "0.52.2",
-      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.52.2.tgz",
-      "integrity": "sha512-GEQWEZmfkOGLdd3XK8ryrfWz3AIP8YymVXiPHEdewrUq7mh0qrKrfHLNCXcbB6sTnMLnOZ3ztSiKcciFUkIJwQ==",
-      "license": "MIT"
-    },
     "examples/monaco-editor-webpack-plugin": {
       "name": "monaco-editor-webpack-plugin-example",
       "version": "1.0.0",
       "dependencies": {
         "css-loader": "^7.0.0",
         "html-webpack-plugin": "^5.0.0",
-        "monaco-editor": "^0.52.0",
+        "monaco-editor": "0.55.1",
         "monaco-editor-webpack-plugin": "^7.0.0",
         "monaco-yaml": "file:../..",
         "style-loader": "^4.0.0",
@@ -82,25 +76,13 @@
         "webpack-dev-server": "^5.0.0"
       }
     },
-    "examples/monaco-editor-webpack-plugin/node_modules/monaco-editor": {
-      "version": "0.52.2",
-      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.52.2.tgz",
-      "integrity": "sha512-GEQWEZmfkOGLdd3XK8ryrfWz3AIP8YymVXiPHEdewrUq7mh0qrKrfHLNCXcbB6sTnMLnOZ3ztSiKcciFUkIJwQ==",
-      "license": "MIT"
-    },
     "examples/vite-example": {
       "version": "1.0.0",
       "dependencies": {
-        "monaco-editor": "^0.52.0",
+        "monaco-editor": "0.55.1",
         "monaco-yaml": "file:../..",
         "vite": "^7.0.0"
       }
-    },
-    "examples/vite-example/node_modules/monaco-editor": {
-      "version": "0.52.2",
-      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.52.2.tgz",
-      "integrity": "sha512-GEQWEZmfkOGLdd3XK8ryrfWz3AIP8YymVXiPHEdewrUq7mh0qrKrfHLNCXcbB6sTnMLnOZ3ztSiKcciFUkIJwQ==",
-      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "@vitest/browser-playwright": "^4.0.0",
         "@vitest/coverage-v8": "^4.0.0",
         "esbuild": "^0.27.0",
-        "monaco-editor": "^0.52.0",
+        "monaco-editor": "^0.55.1",
         "playwright": "^1.0.0",
         "remark-cli": "^12.0.0",
         "remark-preset-remcohaszing": "^3.0.0",
@@ -61,6 +61,12 @@
         "webpack-dev-server": "^5.0.0"
       }
     },
+    "examples/demo/node_modules/monaco-editor": {
+      "version": "0.52.2",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.52.2.tgz",
+      "integrity": "sha512-GEQWEZmfkOGLdd3XK8ryrfWz3AIP8YymVXiPHEdewrUq7mh0qrKrfHLNCXcbB6sTnMLnOZ3ztSiKcciFUkIJwQ==",
+      "license": "MIT"
+    },
     "examples/monaco-editor-webpack-plugin": {
       "name": "monaco-editor-webpack-plugin-example",
       "version": "1.0.0",
@@ -76,6 +82,12 @@
         "webpack-dev-server": "^5.0.0"
       }
     },
+    "examples/monaco-editor-webpack-plugin/node_modules/monaco-editor": {
+      "version": "0.52.2",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.52.2.tgz",
+      "integrity": "sha512-GEQWEZmfkOGLdd3XK8ryrfWz3AIP8YymVXiPHEdewrUq7mh0qrKrfHLNCXcbB6sTnMLnOZ3ztSiKcciFUkIJwQ==",
+      "license": "MIT"
+    },
     "examples/vite-example": {
       "version": "1.0.0",
       "dependencies": {
@@ -83,6 +95,12 @@
         "monaco-yaml": "file:../..",
         "vite": "^7.0.0"
       }
+    },
+    "examples/vite-example/node_modules/monaco-editor": {
+      "version": "0.52.2",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.52.2.tgz",
+      "integrity": "sha512-GEQWEZmfkOGLdd3XK8ryrfWz3AIP8YymVXiPHEdewrUq7mh0qrKrfHLNCXcbB6sTnMLnOZ3ztSiKcciFUkIJwQ==",
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
@@ -2676,6 +2694,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@types/ungap__structured-clone": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@types/ungap__structured-clone/-/ungap__structured-clone-1.2.0.tgz",
@@ -5014,6 +5039,15 @@
       },
       "funding": {
         "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.7.tgz",
+      "integrity": "sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/domutils": {
@@ -7500,6 +7534,18 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/marked": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-14.0.0.tgz",
+      "integrity": "sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -8694,10 +8740,14 @@
       }
     },
     "node_modules/monaco-editor": {
-      "version": "0.52.2",
-      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.52.2.tgz",
-      "integrity": "sha512-GEQWEZmfkOGLdd3XK8ryrfWz3AIP8YymVXiPHEdewrUq7mh0qrKrfHLNCXcbB6sTnMLnOZ3ztSiKcciFUkIJwQ==",
-      "license": "MIT"
+      "version": "0.55.1",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.55.1.tgz",
+      "integrity": "sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A==",
+      "license": "MIT",
+      "dependencies": {
+        "dompurify": "3.2.7",
+        "marked": "14.0.0"
+      }
     },
     "node_modules/monaco-editor-webpack-plugin": {
       "version": "7.1.1",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "@vitest/browser-playwright": "^4.0.0",
     "@vitest/coverage-v8": "^4.0.0",
     "esbuild": "^0.27.0",
-    "monaco-editor": "^0.52.0",
+    "monaco-editor": "^0.55.1",
     "playwright": "^1.0.0",
     "remark-cli": "^12.0.0",
     "remark-preset-remcohaszing": "^3.0.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,7 +21,6 @@ import {
   toTextEdit
 } from 'monaco-languageserver-types'
 import { registerMarkerDataProvider } from 'monaco-marker-data-provider'
-import { createWorkerManager } from 'monaco-worker-manager'
 
 export interface JSONSchema {
   id?: string
@@ -175,6 +174,26 @@ export interface MonacoYamlOptions {
   readonly validate?: boolean
 
   /**
+   * A factory function that creates a new `Worker` for the YAML language service.
+   *
+   * This is required for Monaco Editor **>= 0.55**, which changed the `createWebWorker` API to
+   * require a `Worker` instance. For older versions of Monaco Editor, this option is not needed as
+   * the worker is created automatically via `MonacoEnvironment.getWorker`.
+   *
+   * @example
+   *   Using Vite:
+   *
+   *   ```ts
+   *   import YamlWorker from 'monaco-yaml/yaml.worker?worker'
+   *
+   *   configureMonacoYaml(monaco, {
+   *     worker: () => new YamlWorker()
+   *   })
+   *   ```
+   */
+  readonly worker?: () => Worker
+
+  /**
    * The YAML version to use for parsing.
    *
    * @default '1.2'
@@ -194,6 +213,126 @@ export interface MonacoYaml extends IDisposable {
   getOptions: () => MonacoYamlOptions
 }
 
+interface WorkerManagerOptions {
+  label: string
+  moduleId: string
+  createData: object
+  workerFactory?: () => Worker
+  interval?: number
+  stopWhenIdleFor?: number
+}
+
+/**
+ * Create a worker manager for the YAML language service.
+ *
+ * This is an inline replacement for `monaco-worker-manager`'s `createWorkerManager` that adds
+ * support for Monaco Editor >= 0.55, which requires a `Worker` instance in `createWebWorker`.
+ */
+function createYamlWorkerManager<T>(
+  monaco: MonacoEditor,
+  options: WorkerManagerOptions
+): {
+  dispose: () => void
+  getWorker: (...resources: editor.ITextModel['uri'][]) => Promise<T>
+  updateCreateData: (newCreateData: object) => void
+} {
+  let {
+    createData,
+    interval = 30_000,
+    label,
+    moduleId,
+    stopWhenIdleFor = 120_000,
+    workerFactory
+  } = options
+  let worker: ReturnType<MonacoEditor['editor']['createWebWorker']> | undefined
+  let lastUsedTime = 0
+  let disposed = false
+
+  const stopWorker = (): void => {
+    if (worker) {
+      worker.dispose()
+      worker = undefined
+    }
+  }
+
+  const intervalId = setInterval(() => {
+    if (!worker) {
+      return
+    }
+
+    if (Date.now() - lastUsedTime > stopWhenIdleFor) {
+      stopWorker()
+    }
+  }, interval)
+
+  return {
+    dispose() {
+      disposed = true
+      clearInterval(intervalId)
+      stopWorker()
+    },
+
+    getWorker(...resources) {
+      if (disposed) {
+        throw new Error('Worker manager has been disposed')
+      }
+
+      lastUsedTime = Date.now()
+
+      if (!worker) {
+        if (workerFactory) {
+          // Monaco >= 0.55 path: the consumer provides a Worker factory.
+          //
+          // Monaco 0.55 changed `createWebWorker` to require `opts.worker` (a Worker instance).
+          // Additionally, Monaco no longer sends `createData` through the worker message protocol.
+          //
+          // The yaml worker (via `monaco-worker-manager/worker`'s `initialize`) expects:
+          //   msg1 → triggers `initializeWorker()`, which sets up a new `onmessage`
+          //   msg2 → becomes `createData` (passed to the worker factory function)
+          //   msg3+ → RPC messages handled by `WebWorkerServer`
+          //
+          // Monaco 0.55 sends msg1 = `'-please-ignore-'`, then an INITIALIZE RPC message.
+          // Without intervention, the RPC message is consumed as `createData` — breaking both
+          // the language service initialization and the RPC protocol.
+          //
+          // We intercept the 2nd `postMessage` to inject the real `createData` before the
+          // RPC INITIALIZE message reaches the worker.
+          const rawWorker = workerFactory()
+          const realPostMessage = rawWorker.postMessage.bind(rawWorker)
+          let callCount = 0
+
+          rawWorker.postMessage = function (msg: unknown, transferOrOpts?: unknown) {
+            callCount++
+
+            if (callCount === 2) {
+              realPostMessage(createData)
+              realPostMessage(msg, transferOrOpts as Transferable[])
+              rawWorker.postMessage = realPostMessage
+              return
+            }
+
+            realPostMessage(msg, transferOrOpts as Transferable[])
+          }
+
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          worker = monaco.editor.createWebWorker({ worker: rawWorker, label } as any)
+        } else {
+          // Legacy path for Monaco < 0.55: worker is created internally via MonacoEnvironment.
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          worker = monaco.editor.createWebWorker({ createData, label, moduleId } as any)
+        }
+      }
+
+      return worker.withSyncedResources(resources) as Promise<T>
+    },
+
+    updateCreateData(newCreateData) {
+      createData = newCreateData
+      stopWorker()
+    }
+  }
+}
+
 /**
  * Configure `monaco-yaml`.
  *
@@ -208,7 +347,9 @@ export interface MonacoYaml extends IDisposable {
  *   A disposable object that can be used to update `monaco-yaml`
  */
 export function configureMonacoYaml(monaco: MonacoEditor, options?: MonacoYamlOptions): MonacoYaml {
-  const createData: MonacoYamlOptions = {
+  const { worker: workerFactory, ...yamlOptions } = options ?? {}
+
+  let createData: Omit<MonacoYamlOptions, 'worker'> = {
     completion: true,
     customTags: [],
     enableSchemaRequest: false,
@@ -218,7 +359,7 @@ export function configureMonacoYaml(monaco: MonacoEditor, options?: MonacoYamlOp
     schemas: [],
     validate: true,
     yamlVersion: '1.2',
-    ...options
+    ...yamlOptions
   }
 
   monaco.languages.register({
@@ -228,10 +369,11 @@ export function configureMonacoYaml(monaco: MonacoEditor, options?: MonacoYamlOp
     mimetypes: ['application/x-yaml']
   })
 
-  const workerManager = createWorkerManager<YAMLWorker, MonacoYamlOptions>(monaco, {
+  const workerManager = createYamlWorkerManager<YAMLWorker>(monaco, {
     label: 'yaml',
     moduleId: 'monaco-yaml/yaml.worker',
-    createData
+    createData,
+    workerFactory
   })
 
   const diagnosticMap = new WeakMap<editor.ITextModel, Diagnostic[] | undefined>()
@@ -428,12 +570,13 @@ export function configureMonacoYaml(monaco: MonacoEditor, options?: MonacoYamlOp
     },
 
     async update(newOptions) {
-      workerManager.updateCreateData(Object.assign(createData, newOptions))
+      const { worker: _, ...newYamlOptions } = newOptions
+      workerManager.updateCreateData(Object.assign(createData, newYamlOptions))
       await markerDataProvider.revalidate()
     },
 
     getOptions() {
-      return createData
+      return createData as MonacoYamlOptions
     }
   }
 }


### PR DESCRIPTION
Monaco Editor 0.55 changed the createWebWorker API to require a Worker instance via opts.worker. Additionally, createData is no longer sent through the worker message protocol.

This adds a `worker` option to `configureMonacoYaml()` that allows consumers to provide their own Worker factory function. When provided, the worker manager intercepts the postMessage sequence to inject createData before the RPC INITIALIZE message, preserving compatibility with the existing yaml worker protocol.

For Monaco < 0.55, omit the worker option and use MonacoEnvironment as before. Updated README with usage examples for both Vite and Webpack.