### PR TITLE
Return real values from `defaultMeta` methods on `ajv` instances

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 coverage/
 dist/
+!/fillers/ajv/dist/
 node_modules/
 playwright-report/
 test-results/

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 coverage/
-dist/
-!/fillers/ajv/dist/
+/dist/
 node_modules/
 playwright-report/
 test-results/

--- a/build.js
+++ b/build.js
@@ -37,8 +37,8 @@ await build({
           path: join(import.meta.dirname, 'fillers/json-schema.json')
         }))
         // Ajv would significantly increase bundle size.
-        onResolve({ filter: /^(ajv|ajv-draft-04|ajv\/dist\/\d+)$/ }, () => ({
-          path: join(import.meta.dirname, 'fillers/ajv.ts')
+        onResolve({ filter: /^(ajv|ajv-draft-04|ajv\/dist\/\d+)$/ }, ({ path }) => ({
+          path: join(import.meta.dirname, `fillers/${path}.ts`)
         }))
         // The yaml language service uses path. We can stub it using path-browserify.
         onResolve({ filter: /^path$/ }, () => ({

--- a/fillers/ajv-draft-04.ts
+++ b/fillers/ajv-draft-04.ts
@@ -1,15 +1,8 @@
-function getTrue(): boolean {
-  return true
-}
+import AJVStub from './ajv.js'
 
-export default class AJVDraft04Stub {
+export default class AJVDraft04Stub extends AJVStub {
   // eslint-disable-next-line @typescript-eslint/class-methods-use-this
-  compile(): () => boolean {
-    return getTrue
-  }
-
-  // eslint-disable-next-line @typescript-eslint/class-methods-use-this
-  defaultMeta(): string {
+  override defaultMeta(): string {
     return 'http://json-schema.org/draft-04/schema'
   }
 }

--- a/fillers/ajv-draft-04.ts
+++ b/fillers/ajv-draft-04.ts
@@ -2,7 +2,7 @@ function getTrue(): boolean {
   return true
 }
 
-export default class AJVStub {
+export default class AJVDraft04Stub {
   // eslint-disable-next-line @typescript-eslint/class-methods-use-this
   compile(): () => boolean {
     return getTrue
@@ -10,6 +10,6 @@ export default class AJVStub {
 
   // eslint-disable-next-line @typescript-eslint/class-methods-use-this
   defaultMeta(): string {
-    return 'http://json-schema.org/draft-07/schema'
+    return 'http://json-schema.org/draft-04/schema'
   }
 }

--- a/fillers/ajv/dist/2019.ts
+++ b/fillers/ajv/dist/2019.ts
@@ -1,15 +1,8 @@
-function getTrue(): boolean {
-  return true
-}
+import AJVStub from '../../ajv.js'
 
-export default class AJV2019Stub {
+export default class AJV2019Stub extends AJVStub {
   // eslint-disable-next-line @typescript-eslint/class-methods-use-this
-  compile(): () => boolean {
-    return getTrue
-  }
-
-  // eslint-disable-next-line @typescript-eslint/class-methods-use-this
-  defaultMeta(): string {
+  override defaultMeta(): string {
     return "https://json-schema.org/draft/2019-09/schema"
   }
 }

--- a/fillers/ajv/dist/2019.ts
+++ b/fillers/ajv/dist/2019.ts
@@ -2,7 +2,7 @@ function getTrue(): boolean {
   return true
 }
 
-export default class AJVStub {
+export default class AJV2019Stub {
   // eslint-disable-next-line @typescript-eslint/class-methods-use-this
   compile(): () => boolean {
     return getTrue
@@ -10,6 +10,6 @@ export default class AJVStub {
 
   // eslint-disable-next-line @typescript-eslint/class-methods-use-this
   defaultMeta(): string {
-    return 'http://json-schema.org/draft-07/schema'
+    return "https://json-schema.org/draft/2019-09/schema"
   }
 }

--- a/fillers/ajv/dist/2020.ts
+++ b/fillers/ajv/dist/2020.ts
@@ -2,7 +2,7 @@ function getTrue(): boolean {
   return true
 }
 
-export default class AJVStub {
+export default class AJV2020Stub {
   // eslint-disable-next-line @typescript-eslint/class-methods-use-this
   compile(): () => boolean {
     return getTrue
@@ -10,6 +10,6 @@ export default class AJVStub {
 
   // eslint-disable-next-line @typescript-eslint/class-methods-use-this
   defaultMeta(): string {
-    return 'http://json-schema.org/draft-07/schema'
+    return "https://json-schema.org/draft/2020-12/schema"
   }
 }

--- a/fillers/ajv/dist/2020.ts
+++ b/fillers/ajv/dist/2020.ts
@@ -1,15 +1,8 @@
-function getTrue(): boolean {
-  return true
-}
+import AJVStub from '../../ajv.js'
 
-export default class AJV2020Stub {
+export default class AJV2020Stub extends AJVStub {
   // eslint-disable-next-line @typescript-eslint/class-methods-use-this
-  compile(): () => boolean {
-    return getTrue
-  }
-
-  // eslint-disable-next-line @typescript-eslint/class-methods-use-this
-  defaultMeta(): string {
+  override defaultMeta(): string {
     return "https://json-schema.org/draft/2020-12/schema"
   }
 }


### PR DESCRIPTION
I ran into an issue when updating to `monaco-yaml` v5.5.0; `yaml-language-server` started trying to fetch https://json-schema.org/draft-07/schema, and that violated our CSP.

It turns out that the problem is [here](https://github.com/redhat-developer/yaml-language-server/blob/1.23.0/src/languageservice/services/yamlSchemaService.ts#L1438-L1444); `knownDialectFromSchemaUri` expects the `ajv` instances to return the metaschema URIs  from `defaultMeta()`, but because `monaco-yaml` has stubbed those out to be `undefined`, the function returns `undefined` as well. Subsequently, instead of using the corresponding validator for the known dialect, the `pickSchemaDialect` function [falls through](https://github.com/redhat-developer/yaml-language-server/blob/1.23.0/src/languageservice/services/yamlSchemaService.ts#L1468) to attempting to [load the schema](https://github.com/redhat-developer/yaml-language-server/blob/1.23.0/src/languageservice/services/yamlSchemaService.ts#L1484) from its (normalized) URI.

This PR changes the `ajv` stubs to return real values from the `defaultMeta` methods, which means that `yaml-language-server` can recognise the known dialects, preventing unnecessary network requests.